### PR TITLE
Add authorized Fanatics wide scan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,12 +39,25 @@ EBAY_AUCTION_QUERY_CACHE_TTL_SECONDS=600
 EBAY_MARKETPLACE_INSIGHTS_SCOPE=
 EBAY_SOLD_QUERY_CACHE_TTL_SECONDS=604800
 
-# Fanatics Collect marketplace discovery. Uses their public search-key flow and
-# live fixed-price Algolia index; do not store Fanatics account login credentials.
+# Fanatics Collect access is disabled by default. Their current terms prohibit
+# scraping/systematic retrieval; enable a mode only when written permission or a
+# licensed feed explicitly covers this app and the configured data path.
+FANATICS_COLLECT_AUTHORIZATION_ID=
+FANATICS_COLLECT_SEARCH_AUTHORIZED=false
 FANATICS_COLLECT_GRAPHQL_URL=https://app.fanaticscollect.com/graphql
 FANATICS_COLLECT_ALGOLIA_APP_ID=3XT9C4X62I
 FANATICS_COLLECT_ALGOLIA_INDEX=prod_item_state_v1
 FANATICS_QUERY_CACHE_TTL_SECONDS=86400
+
+# Cursor-based authorized wide-feed contract. The URL must return JSON with an
+# items/listings/data array and nextCursor + hasMore fields. Images are stripped
+# unless the written license includes downstream image use.
+FANATICS_COLLECT_WIDE_SCAN_AUTHORIZED=false
+FANATICS_COLLECT_AUTHORIZED_FEED_URL=
+FANATICS_COLLECT_AUTHORIZED_FEED_TOKEN=
+FANATICS_COLLECT_WIDE_MAX_PAGES=40
+FANATICS_COLLECT_WIDE_TIME_BUDGET_MS=25000
+FANATICS_COLLECT_IMAGE_RIGHTS_AUTHORIZED=false
 
 # Card Hedge API credentials and local guardrails.
 CARD_HEDGE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install
 npm run dev
 ```
 
-The app opens directly into the Backstop workflow: find underpriced players, price a card, and scan active BINs/auctions against the current model. The current source-of-truth path is official Bowman checklists + Wax Pack Hero 1st Bowman evidence + Card Hedge/local sold comps; eBay and Fanatics Collect fixed-price listings are active live-market layers, eBay remains the ending-soon auction layer, and legacy checklist feeds remain optional fallback data.
+The app opens directly into the Backstop workflow: find underpriced players, price a card, and scan active BINs/auctions against the current model. The current source-of-truth path is official Bowman checklists + Wax Pack Hero 1st Bowman evidence + Card Hedge/local sold comps; eBay is the default active-listing layer, while Fanatics Collect is available only through explicitly authorized search/feed access.
 
 ## Product Navigation
 
@@ -40,13 +40,13 @@ Official checklists + Wax Pack Hero 1st lists
   -> checklist universe and card lanes
   -> Card Hedge sold comps + hosted canonical comp cache
   -> base-auto anchors and variation fair values
-  -> live marketplace scans (eBay + Fanatics Collect BINs; eBay auctions)
+  -> live marketplace scans (eBay BINs/auctions; authorized Fanatics Collect feed)
   -> opportunity board, live chart, reject/cleanup loop
 ```
 
-Card Hedge and the canonical comp cache are the pricing core. Production models live in Neon and refresh independently of deployments; the local SQLite database is an offline research and taxonomy workbench. Live marketplace providers only answer "what is active right now?" and raw query pages/snapshots are cached before scoring so multiple users do not repeat the same external calls. eBay Browse powers active BINs and auctions; Fanatics Collect uses its public search-key flow for active fixed-price listings without storing account credentials. The legacy checklist feed is no longer part of normal startup when local checklist data exists.
+Card Hedge and the canonical comp cache are the pricing core. Production models live in Neon and refresh independently of deployments; the local SQLite database is an offline research and taxonomy workbench. Live marketplace providers only answer "what is active right now?" and raw query pages/snapshots are cached before scoring so multiple users do not repeat the same external calls. eBay Browse powers active BINs and auctions. Fanatics Collect access fails closed unless a written authorization reference and approved data path are configured. The legacy checklist feed is no longer part of normal startup when local checklist data exists.
 
-Subscription read: keep Card Hedge and eBay active. Market Movers is now a validation/taxonomy backup unless Card Hedge coverage proves weaker than expected. Fanatics Collect does not require stored login credentials for the current public fixed-price search path. The legacy checklist feed can be cancelled after local checklists and multipliers cover the releases you care about.
+Subscription read: keep Card Hedge and eBay active. Market Movers is now a validation/taxonomy backup unless Card Hedge coverage proves weaker than expected. Fanatics Collect requires written data-access permission or a licensed export/feed before enabling automated retrieval. The legacy checklist feed can be cancelled after local checklists and multipliers cover the releases you care about.
 
 ## Hosted Storage
 
@@ -176,6 +176,12 @@ EBAY_AUCTION_QUERY_CACHE_TTL_SECONDS=600
 `EBAY_ZIP_CODE` improves shipping context. `EBAY_CATEGORY_ID` can narrow search once you choose the correct eBay leaf category for trading cards.
 
 The `/api/ebay/search` proxy caches raw eBay query pages before the app maps and scores them. Fixed-price Browse pages default to 24 hours, so if one visitor scans `Aiva Arquette 2026 Bowman Chrome 1st auto`, the next visitor reuses that page instead of spending another eBay request. Auction pages default to 10 minutes because current bids and end times go stale quickly. The deployed site uses Upstash Redis first, then Vercel Runtime Cache if available, and finally the local SQLite cache in development. Scan stats report live pages versus cached pages so rate-limit savings are visible.
+
+## Fanatics Collect Wide Scan (Authorized Data Only)
+
+The dedicated `/fanatics` page turns an authorized Fanatics inventory feed into a clean Bowman prospect-auto board: player/set search, fair-or-better and near-model bands, raw/graded and max-price filters, several deal sorts, and persistent personal hold targets. The Deals page also includes a Fanatics-only wide-scan action. Both paths fail closed until a written authorization reference and approved cursor feed are configured; they do not crawl Fanatics pages or undocumented endpoints.
+
+See [the Fanatics wide-scan plan and feed contract](docs/FANATICS_COLLECT_WIDE_SCAN.md) for configuration, legal/operational guardrails, response schema, matching rules, and acceptance criteria.
 
 ## eBay Sold Access (Optional)
 

--- a/docs/FANATICS_COLLECT_WIDE_SCAN.md
+++ b/docs/FANATICS_COLLECT_WIDE_SCAN.md
@@ -1,0 +1,106 @@
+# Fanatics Collect Wide Scan
+
+## Outcome
+
+Backstop can run a Fanatics-only, fixed-price inventory sweep from an authorized cursor-based feed, match the returned Bowman cards to the loaded checklist/model universe, and rank the accepted listings by model edge. The integration is disabled by default.
+
+This boundary is intentional. Fanatics Collect's [Terms of Use](https://support.fanaticscollect.com/en_us/terms-of-use-r11C70QTge) currently prohibit scraping, automated data mining, and systematic retrieval. No public developer API or published integration quota was found during implementation. Do not enable the adapter unless Fanatics has granted written permission or supplied a licensed feed/export that explicitly covers this use.
+
+## What is implemented
+
+- Independent Fanatics capability status at `/api/fanatics-collect/status`.
+- Fail-closed authorization checks for both the legacy targeted search path and the wide-feed path.
+- A dedicated `POST /api/fanatics-collect/wide-scan` endpoint.
+- Cursor pagination with page and wall-clock budgets.
+- One bounded retry that honors `Retry-After` for `429` and `503` responses.
+- Cursor-loop detection and explicit `complete` versus `partial` coverage.
+- UUID-based deduplication without collapsing two legitimate listings of the same card.
+- Source observation time and authorization provenance in every scan response.
+- Image removal by default unless the authorization explicitly includes downstream image rights.
+- A strict client matcher that requires an active fixed-price listing, positive ask, Bowman autograph title, year evidence, exactly one checklist player, exactly one release model, and all existing adjacent-product title guards.
+- Marketplace-namespaced identities (`fanatics-collect:<listing id>`).
+- Unknown shipping remains unknown instead of being represented as a known `$0` cost.
+- A dedicated **Wide Fanatics sweep** action on the Live Deals page. It uses every loaded model, switches the result sort to raw dollar edge, and never calls eBay.
+- A dedicated `/fanatics` discovery page with prospect-auto search, fair/near-model bands, raw/graded and max-price filters, deal sorting, and persistent player hold targets.
+- Full sold-cache enrichment in batches rather than stopping at the first 160 players.
+
+## Authorized feed contract
+
+Configure:
+
+```text
+FANATICS_COLLECT_AUTHORIZATION_ID=<written permission or license reference>
+FANATICS_COLLECT_WIDE_SCAN_AUTHORIZED=true
+FANATICS_COLLECT_AUTHORIZED_FEED_URL=https://approved.example/feed
+FANATICS_COLLECT_AUTHORIZED_FEED_TOKEN=<server-side bearer token>
+FANATICS_COLLECT_WIDE_MAX_PAGES=40
+FANATICS_COLLECT_WIDE_TIME_BUDGET_MS=25000
+FANATICS_COLLECT_IMAGE_RIGHTS_AUTHORIZED=false
+```
+
+The server sends a `GET` request with these query parameters:
+
+```text
+limit=<page size>
+cursor=<opaque cursor, omitted on page one>
+query=Bowman
+saleType=FIXED
+status=active
+category=baseball
+```
+
+It sends the bearer token when configured and an `X-Backstop-Authorization-Id` header on every request. The feed response must be JSON:
+
+```json
+{
+  "items": [],
+  "nextCursor": "opaque-next-cursor",
+  "hasMore": true,
+  "total": 1250,
+  "observedAt": "2026-07-11T12:00:00.000Z"
+}
+```
+
+`listings` or `data` can be used instead of `items`; `next_cursor`/`has_more` are also accepted. The final page must return `hasMore: false` or no next cursor. Reaching a page/time budget or repeating a cursor produces a partial scan, and the UI must not treat it as exhaustive.
+
+Each item should supply, when licensed and available:
+
+- a stable listing UUID/ID and Fanatics URL;
+- sale type and current status;
+- title, year, structured release/set, and card number;
+- asking price;
+- grading company/grade;
+- listing/source observation timestamps;
+- seller, offer, and quantity fields;
+- image fields only if downstream display rights are included.
+
+## Matching and pricing guardrails
+
+The query or feed scope only discovers candidates; it never establishes card identity. A listing is scored only after the matcher resolves one model lane. Same-player/same-year release ambiguity is rejected unless structured release evidence resolves it. Draft, Sapphire, Mega, Sterling, Bowman's Best, inserts, digital cards, lots, paper, and other unsupported product families remain outside the normal Bowman Chrome autograph model.
+
+Fanatics Buy Now asks have no buyer's premium, but shipping, tax, and payment costs may still vary. Because the authorized feed contract does not guarantee shipping, the normalized listing stores shipping as unknown. The displayed edge is therefore ask-versus-model, not a guaranteed delivered-cost profit.
+
+Wide results reuse Backstop's sold-comp/fair-value engine. The preset selects **Spread** so the largest raw modeled dollar edges appear first; ROI, conviction, trust, and other existing sorts remain available. Ambiguous and rejected records contribute to scan diagnostics but never enter the ranked deal list.
+
+## Operating rules
+
+1. Written permission must cover automated systematic retrieval, derived price scoring, retention, display, refresh cadence, allowed fields, and image use.
+2. Keep credentials server-side. Never use a Fanatics account session or browser cookies.
+3. Set page/time limits no higher than the licensed quota permits.
+4. Treat `401`, `403`, schema failures, cursor loops, or repeated `429` responses as a stop condition.
+5. A partial run must never imply that unseen prior listings ended.
+6. Keep fixed-price, auction, and sold records in separate lanes. Fanatics auctions require a 20% buyer's premium and extended-bidding logic and are deliberately out of scope for this first wide-scan implementation.
+
+## Acceptance checklist
+
+- Disabled environments perform no Fanatics upstream request.
+- Fanatics-only wide scan performs no eBay request.
+- Duplicate UUIDs collapse; distinct UUIDs for the same card remain distinct.
+- Wrong-year, wrong-player, ambiguous-release, non-auto, non-fixed, inactive, and unsupported-product records do not score.
+- Complete and partial coverage are distinguishable in the API response.
+- The globally highest dollar edge is ranked before presentation limits are applied.
+- Relevant unit, server, lint, type, and production-build checks pass.
+
+## Next step after permission
+
+Replace the generic feed URL contract with Fanatics' supplied schema/authentication details, record their quota and retention terms beside the authorization reference, run a small read-only certification sweep, review matcher diagnostics, and only then raise page/cadence limits.

--- a/server/fanaticsCollect.test.ts
+++ b/server/fanaticsCollect.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { handleFanaticsCollectRoute } from './proxy'
 
-function postJson(body: unknown) {
-  return new Request('http://localhost/api/fanatics-collect/search', {
+function postJson(body: unknown, route = 'search') {
+  return new Request(`http://localhost/api/fanatics-collect/${route}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -17,6 +17,8 @@ function fanaticsEnv(overrides: Record<string, string | undefined> = {}) {
     FANATICS_COLLECT_GRAPHQL_URL: 'https://fanatics.test/graphql',
     FANATICS_COLLECT_ALGOLIA_APP_ID: 'TESTAPP',
     FANATICS_COLLECT_ALGOLIA_INDEX: 'test_index',
+    FANATICS_COLLECT_SEARCH_AUTHORIZED: 'true',
+    FANATICS_COLLECT_AUTHORIZATION_ID: 'fanatics-written-permission-test',
     ...overrides,
   }
 }
@@ -27,6 +29,23 @@ afterEach(() => {
 })
 
 describe('Fanatics Collect proxy', () => {
+  it('fails closed without a written-access authorization reference', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const response = await handleFanaticsCollectRoute(
+      'search',
+      postJson({ queries: ['2026 Bowman Chrome Auto'] }),
+      fanaticsEnv({ FANATICS_COLLECT_SEARCH_AUTHORIZED: undefined, FANATICS_COLLECT_AUTHORIZATION_ID: undefined }),
+    )
+    const payload = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(503)
+    expect(payload.error).toMatch(/written data-access permission/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('validates query batches before requesting a Fanatics search key', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
@@ -137,5 +156,89 @@ describe('Fanatics Collect proxy', () => {
     expect(response.status).toBe(200)
     expect(payload.items).toHaveLength(1)
     expect(payload.stats.queriesRun).toBe(1)
+  })
+
+  it('paginates an authorized wide feed, deduplicates UUIDs, and reports complete coverage', async () => {
+    const cursors: string[] = []
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const parsed = new URL(String(url))
+      cursors.push(parsed.searchParams.get('cursor') ?? '')
+      expect(parsed.origin + parsed.pathname).toBe('https://feed.fanatics.test/listings')
+      expect(parsed.searchParams.get('query')).toBe('Bowman')
+      expect(parsed.searchParams.get('saleType')).toBe('FIXED')
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer feed-token')
+
+      if (!parsed.searchParams.get('cursor')) {
+        return Response.json({
+          items: [
+            { listingUuid: 'one', title: '2026 Bowman Chrome Player One Auto', askingPrice: 100, images: ['private'] },
+            { listingUuid: 'shared', title: '2026 Bowman Chrome Shared Auto', askingPrice: 200 },
+          ],
+          nextCursor: 'page-2',
+          hasMore: true,
+          total: 3,
+          observedAt: '2026-07-11T12:00:00.000Z',
+        })
+      }
+      return Response.json({
+        items: [
+          { listingUuid: 'shared', title: '2026 Bowman Chrome Shared Auto', askingPrice: 190 },
+          { listingUuid: 'two', title: '2026 Bowman Chrome Player Two Auto', askingPrice: 50 },
+        ],
+        hasMore: false,
+        total: 3,
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await handleFanaticsCollectRoute(
+      'wide-scan',
+      postJson({ minPrice: 75, pageSize: 100 }, 'wide-scan'),
+      fanaticsEnv({
+        FANATICS_COLLECT_WIDE_SCAN_AUTHORIZED: 'true',
+        FANATICS_COLLECT_AUTHORIZED_FEED_URL: 'https://feed.fanatics.test/listings',
+        FANATICS_COLLECT_AUTHORIZED_FEED_TOKEN: 'feed-token',
+      }),
+    )
+    const payload = (await response.json()) as {
+      items: Array<Record<string, unknown>>
+      fetchedAt: string
+      coverage: { complete: boolean; pagesFetched: number; stoppedReason: string }
+      stats: { dedupedItems: number; upstreamPagesFetched: number }
+    }
+
+    expect(response.status).toBe(200)
+    expect(cursors).toEqual(['', 'page-2'])
+    expect(payload.items.map((item) => item.listingUuid)).toEqual(['one', 'shared'])
+    expect(payload.items[0]).not.toHaveProperty('images')
+    expect(payload.fetchedAt).toBe('2026-07-11T12:00:00.000Z')
+    expect(payload.coverage).toMatchObject({ complete: true, pagesFetched: 2, stoppedReason: 'complete' })
+    expect(payload.stats).toMatchObject({ dedupedItems: 2, upstreamPagesFetched: 2 })
+  })
+
+  it('marks a wide feed partial when the configured page budget is exhausted', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      items: [{ listingUuid: 'one', title: '2026 Bowman Chrome Player One Auto', askingPrice: 100 }],
+      nextCursor: 'more',
+      hasMore: true,
+    })))
+
+    const response = await handleFanaticsCollectRoute(
+      'wide-scan',
+      postJson({ maxPages: 1 }, 'wide-scan'),
+      fanaticsEnv({
+        FANATICS_COLLECT_WIDE_SCAN_AUTHORIZED: 'true',
+        FANATICS_COLLECT_AUTHORIZED_FEED_URL: 'https://feed.fanatics.test/listings',
+        FANATICS_COLLECT_WIDE_MAX_PAGES: '1',
+      }),
+    )
+    const payload = (await response.json()) as {
+      errors: Array<{ error: string }>
+      coverage: { complete: boolean; stoppedReason: string; nextCursor: string }
+    }
+
+    expect(response.status).toBe(200)
+    expect(payload.coverage).toMatchObject({ complete: false, stoppedReason: 'page-budget', nextCursor: 'more' })
+    expect(payload.errors[0]?.error).toMatch(/page budget/i)
   })
 })

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -38,6 +38,12 @@ const FANATICS_COLLECT_QUERY_CACHE_NAMESPACE = 'backstop-fanatics-collect-query-
 const FANATICS_COLLECT_SEARCH_KEY_TTL_MS = 10 * 60 * 1000
 const FANATICS_COLLECT_QUERY_BATCH_SIZE = 25
 const FANATICS_COLLECT_QUERY_CACHE_TTL_SECONDS = 24 * 60 * 60
+const FANATICS_COLLECT_TERMS_URL = 'https://support.fanaticscollect.com/en_us/terms-of-use-r11C70QTge'
+const FANATICS_COLLECT_WIDE_DEFAULT_PAGE_SIZE = 250
+const FANATICS_COLLECT_WIDE_DEFAULT_MAX_PAGES = 40
+const FANATICS_COLLECT_WIDE_MAX_PAGES = 200
+const FANATICS_COLLECT_WIDE_DEFAULT_TIME_BUDGET_MS = 25_000
+const FANATICS_COLLECT_WIDE_MAX_TIME_BUDGET_MS = 50_000
 const DAVE_ADAMS_BASE_URL = 'https://www.dacardworld.com'
 const DAVE_ADAMS_QUERY_CACHE_NAMESPACE = 'backstop-dave-adams-query-v1'
 const DAVE_ADAMS_QUERY_CACHE_TTL_SECONDS = 6 * 60 * 60
@@ -57,7 +63,7 @@ const MAX_EBAY_QUERIES = 140
 const MAX_EBAY_QUERY_LENGTH = 140
 const PROSPECTPULSE_FUNCTION_ROUTES = new Set(['api-checklists', 'api-listings'])
 const EBAY_ROUTES = new Set(['search', 'sold'])
-const FANATICS_COLLECT_ROUTES = new Set(['status', 'search'])
+const FANATICS_COLLECT_ROUTES = new Set(['status', 'search', 'wide-scan'])
 const DAVE_ADAMS_ROUTES = new Set(['status', 'search'])
 const CARD_HEDGE_ROUTES = new Set([
   'status',
@@ -4358,6 +4364,7 @@ type FanaticsCollectQueryMeta = {
   variationTerm?: string
   baseAutoOnly?: boolean
   lowSerialNonAuto?: boolean
+  superfractorOnly?: boolean
   serialDenominator?: number
 }
 
@@ -4374,6 +4381,36 @@ type FanaticsCollectSearchResult = {
   stats: EbayQueryCacheStats
 }
 
+type FanaticsCollectWideScanPayload = {
+  minPrice?: number | string
+  pageSize?: number | string
+  maxPages?: number | string
+}
+
+type FanaticsCollectAuthorizedFeedPage = {
+  items?: Array<Record<string, unknown>>
+  listings?: Array<Record<string, unknown>>
+  data?: Array<Record<string, unknown>>
+  nextCursor?: string | null
+  next_cursor?: string | null
+  cursor?: string | null
+  hasMore?: boolean
+  has_more?: boolean
+  total?: number | string
+  fetchedAt?: string
+  observedAt?: string
+}
+
+type FanaticsCollectAuthorization = {
+  authorizationId: string
+  searchAuthorized: boolean
+  feedAuthorized: boolean
+  feedUrl: string
+  feedToken: string
+  imageRights: boolean
+  issue?: string
+}
+
 function fanaticsCollectString(value: unknown, fallback = '') {
   if (typeof value !== 'string') return fallback
   const trimmed = value.trim()
@@ -4383,6 +4420,72 @@ function fanaticsCollectString(value: unknown, fallback = '') {
 function fanaticsCollectNumber(value: unknown, fallback = 0) {
   const parsed = Number(String(value ?? '').replace(/[$,%\s,]/g, ''))
   return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function fanaticsCollectEnabled(value: unknown) {
+  return /^(1|true|yes|on)$/i.test(String(value ?? '').trim())
+}
+
+function fanaticsCollectAuthorization(env: ServerEnv): FanaticsCollectAuthorization {
+  const authorizationId = fanaticsCollectString(env.FANATICS_COLLECT_AUTHORIZATION_ID)
+  const feedUrl = fanaticsCollectString(env.FANATICS_COLLECT_AUTHORIZED_FEED_URL)
+  const feedToken = fanaticsCollectString(env.FANATICS_COLLECT_AUTHORIZED_FEED_TOKEN)
+  const searchAttested = fanaticsCollectEnabled(env.FANATICS_COLLECT_SEARCH_AUTHORIZED)
+  const feedAttested = fanaticsCollectEnabled(env.FANATICS_COLLECT_WIDE_SCAN_AUTHORIZED)
+  const imageRights = fanaticsCollectEnabled(env.FANATICS_COLLECT_IMAGE_RIGHTS_AUTHORIZED)
+
+  let normalizedFeedUrl = ''
+  let issue = ''
+  if (feedUrl) {
+    try {
+      const parsed = new URL(feedUrl)
+      const localHttp = parsed.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname)
+      if (parsed.protocol !== 'https:' && !localHttp) {
+        issue = 'The authorized Fanatics feed URL must use HTTPS (localhost HTTP is allowed for development).'
+      } else {
+        normalizedFeedUrl = parsed.toString()
+      }
+    } catch {
+      issue = 'The authorized Fanatics feed URL is invalid.'
+    }
+  }
+
+  if ((searchAttested || feedAttested) && !authorizationId) {
+    issue = 'Set FANATICS_COLLECT_AUTHORIZATION_ID to the written permission or licensed-feed reference.'
+  }
+
+  return {
+    authorizationId,
+    searchAuthorized: searchAttested && Boolean(authorizationId),
+    feedAuthorized: feedAttested && Boolean(authorizationId) && Boolean(normalizedFeedUrl) && !issue,
+    feedUrl: normalizedFeedUrl,
+    feedToken,
+    imageRights,
+    issue: issue || undefined,
+  }
+}
+
+function requireFanaticsCollectSearchAuthorization(env: ServerEnv) {
+  const authorization = fanaticsCollectAuthorization(env)
+  if (!authorization.searchAuthorized) {
+    throw new ProxyRequestError(
+      503,
+      `Fanatics Collect search is disabled until written data-access permission is configured. See ${FANATICS_COLLECT_TERMS_URL}`,
+    )
+  }
+  return authorization
+}
+
+function requireFanaticsCollectFeedAuthorization(env: ServerEnv) {
+  const authorization = fanaticsCollectAuthorization(env)
+  if (!authorization.feedAuthorized) {
+    throw new ProxyRequestError(
+      503,
+      authorization.issue ??
+        `Fanatics Collect wide scan requires an authorized feed and written data-access permission. See ${FANATICS_COLLECT_TERMS_URL}`,
+    )
+  }
+  return authorization
 }
 
 function fanaticsCollectQueryFrom(value: FanaticsCollectQueryMeta | string) {
@@ -4406,6 +4509,7 @@ function fanaticsCollectQueryFrom(value: FanaticsCollectQueryMeta | string) {
     variationTerm: fanaticsCollectString(value.variationTerm),
     baseAutoOnly: Boolean(value.baseAutoOnly),
     lowSerialNonAuto: Boolean(value.lowSerialNonAuto),
+    superfractorOnly: Boolean(value.superfractorOnly),
     serialDenominator: fanaticsCollectNumber(value.serialDenominator, 0) || undefined,
   }
 }
@@ -4479,6 +4583,7 @@ function dedupeFanaticsCollectHits(items: Array<Record<string, unknown>>) {
 }
 
 async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env: ServerEnv): Promise<FanaticsCollectSearchResult> {
+  requireFanaticsCollectSearchAuthorization(env)
   const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
   const appId = env.FANATICS_COLLECT_ALGOLIA_APP_ID?.trim() || FANATICS_COLLECT_ALGOLIA_APP_ID
   const indexName = env.FANATICS_COLLECT_ALGOLIA_INDEX?.trim() || FANATICS_COLLECT_ALGOLIA_INDEX
@@ -4508,6 +4613,16 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
       'images',
       'allowOffers',
       'quantityAvailable',
+      'year',
+      'productTitle',
+      'categoryParent',
+      'subCategory1',
+      'cardNumber',
+      'serial',
+      'grade',
+      'gradingService',
+      'listedAt',
+      'updatedAt',
     ],
     attributesToHighlight: [],
   }))
@@ -4628,10 +4743,217 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
   return response
 }
 
+function fanaticsCollectWideItemIdentity(item: Record<string, unknown>) {
+  return fanaticsCollectString(item.listingUuid) ||
+    fanaticsCollectString(item.listing_id) ||
+    fanaticsCollectString(item.listingId) ||
+    fanaticsCollectString(item.objectID) ||
+    fanaticsCollectString(item.id) ||
+    fanaticsCollectString(item.url) ||
+    fanaticsCollectString(item.listingUrl)
+}
+
+function fanaticsCollectWideItemPrice(item: Record<string, unknown>) {
+  const values = [
+    item.askingPrice,
+    item.asking_price,
+    item.buyNowPrice,
+    item.buy_now_price,
+    item.currentPrice,
+    item.current_price,
+    item.price,
+  ]
+  for (const value of values) {
+    const parsed = fanaticsCollectNumber(value, Number.NaN)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return 0
+}
+
+function fanaticsCollectWideFeedItems(page: FanaticsCollectAuthorizedFeedPage) {
+  if (Array.isArray(page.items)) return page.items
+  if (Array.isArray(page.listings)) return page.listings
+  if (Array.isArray(page.data)) return page.data
+  return []
+}
+
+function fanaticsCollectWideNextCursor(page: FanaticsCollectAuthorizedFeedPage) {
+  return fanaticsCollectString(page.nextCursor) ||
+    fanaticsCollectString(page.next_cursor) ||
+    fanaticsCollectString(page.cursor)
+}
+
+function stripUnlicensedFanaticsImages(item: Record<string, unknown>, imageRights: boolean) {
+  if (imageRights) return item
+  const sanitized = { ...item }
+  for (const key of ['image', 'images', 'imageSets', 'imageUrl', 'image_url', 'thumbnail', 'thumbnailUrl']) {
+    delete sanitized[key]
+  }
+  return sanitized
+}
+
+function fanaticsCollectFeedRetryDelay(response: Response) {
+  const retryAfter = response.headers.get('retry-after')
+  if (!retryAfter) return 0
+  const seconds = Number(retryAfter)
+  if (Number.isFinite(seconds)) return Math.min(2_000, Math.max(0, seconds * 1_000))
+  const dateMs = Date.parse(retryAfter)
+  return Number.isFinite(dateMs) ? Math.min(2_000, Math.max(0, dateMs - Date.now())) : 0
+}
+
+async function waitForFanaticsFeedRetry(delayMs: number) {
+  if (delayMs <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+async function fetchFanaticsCollectAuthorizedPage(options: {
+  authorization: FanaticsCollectAuthorization
+  cursor: string
+  pageSize: number
+  signal: AbortSignal
+}) {
+  const url = new URL(options.authorization.feedUrl)
+  url.searchParams.set('limit', String(options.pageSize))
+  url.searchParams.set('query', 'Bowman')
+  url.searchParams.set('saleType', 'FIXED')
+  url.searchParams.set('status', 'active')
+  url.searchParams.set('category', 'baseball')
+  if (options.cursor) url.searchParams.set('cursor', options.cursor)
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'X-Backstop-Authorization-Id': options.authorization.authorizationId,
+  }
+  if (options.authorization.feedToken) headers.Authorization = `Bearer ${options.authorization.feedToken}`
+
+  let upstream = await fetch(url, { method: 'GET', headers, signal: options.signal })
+  if (upstream.status === 429 || upstream.status === 503) {
+    await waitForFanaticsFeedRetry(fanaticsCollectFeedRetryDelay(upstream))
+    upstream = await fetch(url, { method: 'GET', headers, signal: options.signal })
+  }
+
+  const payload = (await upstream.json().catch(() => null)) as FanaticsCollectAuthorizedFeedPage | { error?: string; message?: string } | null
+  if (!upstream.ok || !payload || typeof payload !== 'object') {
+    const message = payload && 'message' in payload
+      ? fanaticsCollectString(payload.message)
+      : payload && 'error' in payload
+        ? fanaticsCollectString(payload.error)
+        : `${upstream.status} ${upstream.statusText}`.trim()
+    throw new ProxyRequestError(upstream.status || 502, `Authorized Fanatics feed failed: ${message || 'invalid response'}`)
+  }
+  return payload as FanaticsCollectAuthorizedFeedPage
+}
+
+async function scanAuthorizedFanaticsCollectFeed(payload: FanaticsCollectWideScanPayload, env: ServerEnv) {
+  const authorization = requireFanaticsCollectFeedAuthorization(env)
+  const minPrice = Math.max(0, fanaticsCollectNumber(payload.minPrice, 0))
+  const pageSize = clampInt(payload.pageSize, FANATICS_COLLECT_WIDE_DEFAULT_PAGE_SIZE, 1, 1_000)
+  const configuredMaxPages = clampInt(
+    env.FANATICS_COLLECT_WIDE_MAX_PAGES,
+    FANATICS_COLLECT_WIDE_DEFAULT_MAX_PAGES,
+    1,
+    FANATICS_COLLECT_WIDE_MAX_PAGES,
+  )
+  const maxPages = clampInt(payload.maxPages, configuredMaxPages, 1, configuredMaxPages)
+  const timeBudgetMs = clampInt(
+    env.FANATICS_COLLECT_WIDE_TIME_BUDGET_MS,
+    FANATICS_COLLECT_WIDE_DEFAULT_TIME_BUDGET_MS,
+    1_000,
+    FANATICS_COLLECT_WIDE_MAX_TIME_BUDGET_MS,
+  )
+  const startedAt = Date.now()
+  const deadline = startedAt + timeBudgetMs
+  const seenCursors = new Set<string>()
+  const itemsById = new Map<string, Record<string, unknown>>()
+  let cursor = ''
+  let pagesFetched = 0
+  let upstreamTotal = 0
+  let sourceFetchedAt = ''
+  let stoppedReason: 'complete' | 'page-budget' | 'time-budget' | 'cursor-loop' = 'complete'
+
+  while (pagesFetched < maxPages) {
+    if (Date.now() >= deadline) {
+      stoppedReason = 'time-budget'
+      break
+    }
+    if (cursor && seenCursors.has(cursor)) {
+      stoppedReason = 'cursor-loop'
+      break
+    }
+    if (cursor) seenCursors.add(cursor)
+
+    const remainingMs = Math.max(500, deadline - Date.now())
+    const page = await fetchFanaticsCollectAuthorizedPage({
+      authorization,
+      cursor,
+      pageSize,
+      signal: AbortSignal.timeout(remainingMs),
+    })
+    pagesFetched += 1
+    const pageItems = fanaticsCollectWideFeedItems(page)
+    upstreamTotal = Math.max(upstreamTotal, fanaticsCollectNumber(page.total, 0))
+    sourceFetchedAt = fanaticsCollectString(page.fetchedAt) || fanaticsCollectString(page.observedAt) || sourceFetchedAt
+
+    for (const rawItem of pageItems) {
+      const identity = fanaticsCollectWideItemIdentity(rawItem)
+      if (!identity || (minPrice > 0 && fanaticsCollectWideItemPrice(rawItem) < minPrice)) continue
+      itemsById.set(identity, stripUnlicensedFanaticsImages(rawItem, authorization.imageRights))
+    }
+
+    const nextCursor = fanaticsCollectWideNextCursor(page)
+    const hasMore = page.hasMore ?? page.has_more ?? Boolean(nextCursor)
+    if (!hasMore || !nextCursor) {
+      stoppedReason = 'complete'
+      cursor = ''
+      break
+    }
+    cursor = nextCursor
+  }
+
+  if (cursor && stoppedReason === 'complete' && pagesFetched >= maxPages) stoppedReason = 'page-budget'
+  const complete = stoppedReason === 'complete'
+  return {
+    items: [...itemsById.values()],
+    errors: complete ? [] : [{ error: `Authorized Fanatics feed stopped at the ${stoppedReason.replace('-', ' ')}.` }],
+    fetchedAt: sourceFetchedAt || new Date().toISOString(),
+    provenance: {
+      mode: 'authorized-feed',
+      authorizationId: authorization.authorizationId,
+      imageRights: authorization.imageRights,
+    },
+    coverage: {
+      complete,
+      stoppedReason,
+      nextCursor: cursor || null,
+      pageSize,
+      maxPages,
+      pagesFetched,
+      durationMs: Date.now() - startedAt,
+    },
+    stats: {
+      queriesRun: 1,
+      queriesSucceeded: complete ? 1 : 0,
+      queriesFailed: complete ? 0 : 1,
+      pagesFetched,
+      upstreamTotal: upstreamTotal || itemsById.size,
+      dedupedItems: itemsById.size,
+      cacheHits: 0,
+      cacheMisses: 0,
+      cacheWrites: 0,
+      cacheSkips: 0,
+      redisCacheHits: 0,
+      runtimeCacheHits: 0,
+      sqliteCacheHits: 0,
+      upstreamPagesFetched: pagesFetched,
+    },
+  }
+}
+
 export async function handleFanaticsCollectRoute(route: string, request: Request, env: ServerEnv) {
   if (!FANATICS_COLLECT_ROUTES.has(route)) return new Response(null, { status: 404 })
   if (route === 'status' && request.method !== 'GET') return new Response(null, { status: 404 })
   if (route === 'search' && request.method !== 'POST') return new Response(null, { status: 404 })
+  if (route === 'wide-scan' && request.method !== 'POST') return new Response(null, { status: 404 })
 
   try {
     if (route === 'search') {
@@ -4642,16 +4964,25 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
       return jsonResponse(200, search)
     }
 
+    if (route === 'wide-scan') {
+      const unsafePost = rejectUnsafePost(request)
+      if (unsafePost) return unsafePost
+      const payload = await readJsonBody<FanaticsCollectWideScanPayload>(request, MAX_EBAY_BODY_BYTES)
+      return jsonResponse(200, await scanAuthorizedFanaticsCollectFeed(payload, env))
+    }
+
+    const authorization = fanaticsCollectAuthorization(env)
     const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
-    const appId = env.FANATICS_COLLECT_ALGOLIA_APP_ID?.trim() || FANATICS_COLLECT_ALGOLIA_APP_ID
-    const indexName = env.FANATICS_COLLECT_ALGOLIA_INDEX?.trim() || FANATICS_COLLECT_ALGOLIA_INDEX
     let reachable = false
-    let message = 'Fanatics Collect public search is ready.'
-    try {
-      await fetchFanaticsCollectSearchKey(graphqlUrl)
-      reachable = true
-    } catch (error) {
-      message = error instanceof Error ? error.message : 'Fanatics Collect public search is unavailable.'
+    let message = authorization.issue ?? 'Fanatics Collect search requires written data-access permission.'
+    if (authorization.searchAuthorized) {
+      try {
+        await fetchFanaticsCollectSearchKey(graphqlUrl)
+        reachable = true
+        message = 'Authorized Fanatics Collect targeted search is ready.'
+      } catch (error) {
+        message = error instanceof Error ? error.message : 'Authorized Fanatics Collect search is unavailable.'
+      }
     }
 
     return jsonResponse(200, {
@@ -4659,11 +4990,31 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
       label: 'Fanatics Collect',
       configured: reachable,
       reachable,
-      mode: reachable ? 'public-algolia-search' : 'offline',
-      graphqlUrl,
+      mode: reachable ? 'authorized-targeted-search' : 'disabled',
       marketplaceUrl: FANATICS_COLLECT_MARKETPLACE_URL,
-      algoliaAppId: appId,
-      algoliaIndex: indexName,
+      termsUrl: FANATICS_COLLECT_TERMS_URL,
+      authorization: {
+        configured: Boolean(authorization.authorizationId),
+        authorizationId: authorization.authorizationId || null,
+      },
+      targetedSearch: {
+        configured: authorization.searchAuthorized && reachable,
+        reachable,
+      },
+      wideScan: {
+        configured: authorization.feedAuthorized,
+        mode: authorization.feedAuthorized ? 'authorized-feed' : 'disabled',
+        imageRights: authorization.imageRights,
+        maxPages: clampInt(
+          env.FANATICS_COLLECT_WIDE_MAX_PAGES,
+          FANATICS_COLLECT_WIDE_DEFAULT_MAX_PAGES,
+          1,
+          FANATICS_COLLECT_WIDE_MAX_PAGES,
+        ),
+        message: authorization.feedAuthorized
+          ? 'Authorized Fanatics Collect wide feed is ready.'
+          : authorization.issue ?? 'Configure a licensed/authorized Fanatics feed to enable wide scan.',
+      },
       message,
     })
   } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   Package,
   Radio,
   RefreshCw,
+  ScanSearch,
   Search,
   ShieldCheck,
   Sigma,
@@ -29,6 +30,7 @@ import type { CSSProperties, MouseEvent as ReactMouseEvent, PointerEvent as Reac
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import './BackstopV2.css'
+import { FanaticsCollectPage } from './FanaticsCollectPage'
 import {
   fetchChecklistCatalog,
   fetchChecklistModel,
@@ -42,7 +44,12 @@ import {
   type EbayBinSearchMode,
   type EbayStatus,
 } from './lib/ebay'
-import { fetchFanaticsCollectBinListings } from './lib/fanaticsCollect'
+import {
+  fetchFanaticsCollectBinListings,
+  fetchFanaticsCollectStatus,
+  fetchFanaticsCollectWideListings,
+  type FanaticsCollectStatus,
+} from './lib/fanaticsCollect'
 import { impliedDynastyBasePrice, scoreDynastyValueOpportunity } from './lib/dynastyValue'
 import {
   capLiveMarketOpportunities,
@@ -219,7 +226,7 @@ type QuickGradeKey =
   | 'sgc-10'
   | 'cgc-9'
   | 'cgc-10'
-type WorkMode = 'lookup' | 'deals' | 'price' | 'health' | 'case-hits' | 'wax'
+type WorkMode = 'lookup' | 'deals' | 'fanatics' | 'price' | 'health' | 'case-hits' | 'wax'
 type FreshnessTone = 'fresh' | 'watch' | 'stale' | 'empty' | 'offline'
 type AppRoute = 'desk' | 'marlins'
 type BinVariationOption = {
@@ -637,6 +644,7 @@ const MARLINS_ROUTE_PATH = '/teams/marlins'
 const WORK_MODE_PATHS: Record<WorkMode, string> = {
   lookup: '/',
   deals: '/deals',
+  fanatics: '/fanatics',
   price: '/price',
   health: '/health',
   'case-hits': '/case-hits',
@@ -2520,6 +2528,7 @@ function WorkflowCommand({
   pricedRows,
   topBase,
   dealCount,
+  fanaticsDealCount,
   listingCount,
   modelReady,
 }: {
@@ -2529,6 +2538,7 @@ function WorkflowCommand({
   pricedRows: number
   topBase: number
   dealCount: number
+  fanaticsDealCount: number
   listingCount: number
   modelReady: boolean
 }) {
@@ -2564,6 +2574,15 @@ function WorkflowCommand({
       icon: <Calculator size={19} />,
     },
     {
+      mode: 'fanatics' as const,
+      tier: 'secondary',
+      eyebrow: 'Collect',
+      title: 'Fanatics Finds',
+      description: 'Prospect autos at model',
+      value: fanaticsDealCount.toLocaleString(),
+      icon: <Store size={19} />,
+    },
+    {
       mode: 'case-hits' as const,
       tier: 'secondary',
       eyebrow: 'Rare',
@@ -2595,7 +2614,7 @@ function WorkflowCommand({
     ['lookup', 'deals', 'price'].includes(item.mode),
   )
   const secondaryMobileItems = navigationItems.filter((item) =>
-    ['case-hits', 'wax', 'health'].includes(item.mode),
+    ['fanatics', 'case-hits', 'wax', 'health'].includes(item.mode),
   )
   const secondaryModeActive = secondaryMobileItems.some((item) => item.mode === mode)
 
@@ -6319,6 +6338,7 @@ function BinRadar({
   scan,
   auctionScan,
   ebayStatus,
+  fanaticsStatus,
   loading,
   auctionLoading,
   modelLoading,
@@ -6348,6 +6368,7 @@ function BinRadar({
   onScanBaseAutos,
   onScanLowSerial,
   onScanSuperfractors,
+  onScanFanaticsWide,
   resultsRef,
 }: {
   models: ChecklistModel[]
@@ -6362,6 +6383,7 @@ function BinRadar({
   scan: EbayBinScanResult | null
   auctionScan: EbayBinScanResult | null
   ebayStatus: EbayStatus | null
+  fanaticsStatus: FanaticsCollectStatus | null
   loading: boolean
   auctionLoading: boolean
   modelLoading: boolean
@@ -6391,9 +6413,14 @@ function BinRadar({
   onScanBaseAutos: () => void
   onScanLowSerial: () => void
   onScanSuperfractors: () => void
+  onScanFanaticsWide: () => void
   resultsRef: RefObject<HTMLDivElement | null>
 }) {
-  const configured = Boolean(ebayStatus?.configured)
+  const ebayConfigured = Boolean(ebayStatus?.configured)
+  const fanaticsTargetedConfigured = Boolean(fanaticsStatus?.targetedSearch?.configured)
+  const fanaticsWideConfigured = Boolean(fanaticsStatus?.wideScan?.configured)
+  const targetedConfigured = ebayConfigured || fanaticsTargetedConfigured
+  const configured = targetedConfigured || fanaticsWideConfigured
   const latestFetchedAt = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleTimeString() : null
   const listingMarketplaceCounts = scan ? marketplaceCountsFromListings(scan.listings) : []
   const opportunityMarketplaceCounts = opportunities.length ? marketplaceCountsFromOpportunities(opportunities) : []
@@ -6442,12 +6469,13 @@ function BinRadar({
         ? 'Browse cache on'
         : 'Browse cache off'
   const busy = loading || auctionLoading
-  const canScan = configured && setCount > 0 && hasPlayerUniverse && hasFocus && hasTargetQueue && !busy && !modelLoading
-  const canScanBaseAutos = configured && setCount > 0 && hasPlayerUniverse && hasTargetQueue && !busy && !modelLoading
-  const canScanLowSerial = configured && setCount > 0 && hasPlayerUniverse && valuePlayerCount > 0 && !busy && !modelLoading
-  const canScanSuperfractors = configured && setCount > 0 && hasPlayerUniverse && !busy && !modelLoading
-  const canScanValueTargets = configured && setCount > 0 && hasPlayerUniverse && valuePlayerCount > 0 && !busy && !modelLoading
-  const canScanTopProspects = configured && setCount > 0 && hasPlayerUniverse && prospectPlayerCount > 0 && !busy && !modelLoading
+  const canScan = targetedConfigured && setCount > 0 && hasPlayerUniverse && hasFocus && hasTargetQueue && !busy && !modelLoading
+  const canScanBaseAutos = targetedConfigured && setCount > 0 && hasPlayerUniverse && hasTargetQueue && !busy && !modelLoading
+  const canScanLowSerial = targetedConfigured && setCount > 0 && hasPlayerUniverse && valuePlayerCount > 0 && !busy && !modelLoading
+  const canScanSuperfractors = targetedConfigured && setCount > 0 && hasPlayerUniverse && !busy && !modelLoading
+  const canScanValueTargets = targetedConfigured && setCount > 0 && hasPlayerUniverse && valuePlayerCount > 0 && !busy && !modelLoading
+  const canScanTopProspects = targetedConfigured && setCount > 0 && hasPlayerUniverse && prospectPlayerCount > 0 && !busy && !modelLoading
+  const canScanFanaticsWide = fanaticsWideConfigured && setCount > 0 && hasPlayerUniverse && !busy && !modelLoading
   const queueWaitingLabel =
     playerScope === 'value-25' ? 'Value board waiting' : playerScope === 'prospect-100' ? 'Top 100 waiting' : 'Target 50 waiting'
   let readinessLabel = 'Ready'
@@ -6468,7 +6496,7 @@ function BinRadar({
   else if (setCount === 0 || !hasPlayerUniverse) scanButtonLabel = 'Player list needed'
   else if (!hasTargetQueue) scanButtonLabel = queueWaitingLabel
   else if (!hasFocus) scanButtonLabel = searchMode === 'player' ? 'Enter player' : 'Enter variation'
-  const auctionButtonLabel = auctionLoading ? 'Scanning auctions' : modelLoading ? 'Model loading' : configured ? 'Auctions only' : 'eBay offline'
+  const auctionButtonLabel = auctionLoading ? 'Scanning auctions' : modelLoading ? 'Model loading' : ebayConfigured ? 'Auctions only' : 'eBay offline'
   const focusPlaceholder = searchMode === 'player' ? 'Eli Willits' : 'Select variation'
   const scopeLabel =
     playerScope === 'value-25'
@@ -6518,7 +6546,15 @@ function BinRadar({
         <div className="bin-radar-pills">
           <span className={configured ? 'connected' : 'offline'}>
             {configured ? <Wifi size={14} /> : <WifiOff size={14} />}
-            {configured ? 'eBay + Fanatics' : 'eBay keys needed'}
+            {ebayConfigured && (fanaticsTargetedConfigured || fanaticsWideConfigured)
+              ? 'eBay + Fanatics'
+              : ebayConfigured
+                ? 'eBay live'
+                : fanaticsWideConfigured
+                  ? 'Fanatics authorized feed'
+                  : fanaticsTargetedConfigured
+                    ? 'Fanatics targeted search'
+                    : 'Marketplace unavailable'}
           </span>
           {configured ? <span className={ebayStatus?.cache?.enabled ? 'connected' : 'offline'}>{browseCacheLabel}</span> : null}
           <span className={hasPlayerUniverse ? 'connected' : 'offline'}>{readinessLabel}</span>
@@ -6557,6 +6593,19 @@ function BinRadar({
         </div>
       </div>
       <div className="bin-preset-strip" aria-label="High value scan presets">
+        <button
+          className={`preset-scan-card ${fanaticsWideConfigured ? 'primary-preset' : ''}`}
+          type="button"
+          onClick={onScanFanaticsWide}
+          disabled={!canScanFanaticsWide}
+          title={fanaticsStatus?.wideScan?.message}
+        >
+          <ScanSearch size={17} />
+          <span>
+            <strong>Wide Fanatics sweep</strong>
+            <small>{fanaticsWideConfigured ? `All ${playerCount.toLocaleString()} loaded player lanes` : 'Requires approved Fanatics data access'}</small>
+          </span>
+        </button>
         <button className="preset-scan-card primary-preset" type="button" onClick={onScanValueTargets} disabled={!canScanValueTargets}>
           <Brain size={17} />
           <span>
@@ -6593,6 +6642,14 @@ function BinRadar({
           </span>
         </button>
       </div>
+      {!fanaticsWideConfigured ? (
+        <div className="bin-control-note">
+          <span>
+            Wide Fanatics scans stay disabled until an authorized feed and written data-access reference are configured.{' '}
+            <a href={fanaticsStatus?.termsUrl} target="_blank" rel="noreferrer">Fanatics terms</a>
+          </span>
+        </div>
+      ) : null}
 
       <details className="bin-advanced-controls">
         <summary>
@@ -6746,7 +6803,7 @@ function BinRadar({
               <RefreshCw size={16} className={loading || auctionLoading ? 'spin' : undefined} />
               {scanButtonLabel}
             </button>
-            <button className="ghost-button value-scan-button" type="button" onClick={onScanAuctions} disabled={!canScan}>
+            <button className="ghost-button value-scan-button" type="button" onClick={onScanAuctions} disabled={!canScan || !ebayConfigured}>
               <Activity size={16} className={auctionLoading ? 'spin' : undefined} />
               {auctionButtonLabel}
             </button>
@@ -8506,6 +8563,7 @@ function App() {
     typeof window === 'undefined' ? 'desk' : appRouteFromPath(window.location.pathname),
   )
   const [ebayStatus, setEbayStatus] = useState<EbayStatus | null>(null)
+  const [fanaticsStatus, setFanaticsStatus] = useState<FanaticsCollectStatus | null>(null)
   const [binListings, setBinListings] = useState<MarketplaceListing[]>([])
   const [binLoading, setBinLoading] = useState(false)
   const [binError, setBinError] = useState<string | null>(null)
@@ -8891,6 +8949,7 @@ function App() {
     let active = true
     const catalogController = new AbortController()
     const ebayController = new AbortController()
+    const fanaticsController = new AbortController()
     const liveMarketController = new AbortController()
     const observabilityController = new AbortController()
     const rankingsController = new AbortController()
@@ -8906,6 +8965,31 @@ function App() {
             marketplaceId: 'EBAY_US',
             hasCategoryId: false,
             message: statusError instanceof Error ? statusError.message : 'Could not read eBay status',
+          })
+        }
+      })
+    fetchFanaticsCollectStatus(fanaticsController.signal)
+      .then((status) => {
+        if (active) setFanaticsStatus(status)
+      })
+      .catch((statusError) => {
+        if (active && !fanaticsController.signal.aborted) {
+          setFanaticsStatus({
+            provider: 'fanatics-collect',
+            label: 'Fanatics Collect',
+            configured: false,
+            reachable: false,
+            mode: 'disabled',
+            marketplaceUrl: 'https://www.fanaticscollect.com/marketplace?type=FIXED',
+            termsUrl: 'https://support.fanaticscollect.com/en_us/terms-of-use-r11C70QTge',
+            wideScan: {
+              configured: false,
+              mode: 'disabled',
+              imageRights: false,
+              maxPages: 0,
+              message: statusError instanceof Error ? statusError.message : 'Could not read Fanatics Collect status',
+            },
+            message: statusError instanceof Error ? statusError.message : 'Could not read Fanatics Collect status',
           })
         }
       })
@@ -8977,6 +9061,7 @@ function App() {
       active = false
       catalogController.abort()
       ebayController.abort()
+      fanaticsController.abort()
       liveMarketController.abort()
       observabilityController.abort()
       rankingsController.abort()
@@ -10194,15 +10279,89 @@ function App() {
   }
 
   async function loadSalesCacheModelsForListings(listings: MarketplaceListing[], signal?: AbortSignal) {
-    const playerNames = playerNamesFromListings(listings)
+    const playerNames = playerNamesFromListings(listings, 3_000)
     if (playerNames.length === 0) return {}
 
-    const response = await fetchSalesCachePlayers(playerNames, signal)
-    const record = salesCacheModelsToRecord(response.players ?? [])
+    const batches: string[][] = []
+    for (let index = 0; index < playerNames.length; index += 140) batches.push(playerNames.slice(index, index + 140))
+    const responses = await mapWithConcurrency(batches, 3, (batch) => fetchSalesCachePlayers(batch, signal))
+    const record = salesCacheModelsToRecord(responses.flatMap((response) => response.players ?? []))
     if (Object.keys(record).length > 0) {
       setActiveSalesCacheModels((current) => ({ ...current, ...record }))
     }
     return record
+  }
+
+  async function scanFanaticsCollectWide(destination: 'deals' | 'fanatics' = 'deals') {
+    const scanModels = binModelOptions.filter((model) => model.players.length > 0)
+    if (scanModels.length === 0) {
+      setBinError('No checklist models are loaded for the Fanatics wide scan.')
+      return
+    }
+    if (!fanaticsStatus?.wideScan?.configured) {
+      setBinError(
+        fanaticsStatus?.wideScan?.message ??
+          'Fanatics Collect wide scan requires an approved data feed and written data-access permission.',
+      )
+      return
+    }
+
+    navigateWorkMode(destination)
+    revealDealResults()
+    setBinModelKey(BIN_ALL_MODELS_KEY)
+    setBinSearchMode('checklist')
+    setBinSearchTerm('')
+    setBinPlayerScope('all')
+    setBinResultSort('edge-desc')
+    resetAuctionScan()
+    binRequestRef.current?.abort()
+    const controller = new AbortController()
+    binRequestRef.current = controller
+    setBinLoading(true)
+    setBinError(null)
+    setLastRejectedListing(null)
+
+    try {
+      const scanResult = await fetchFanaticsCollectWideListings({
+        models: scanModels,
+        minPrice: binMinPrice,
+        maxPages: fanaticsStatus.wideScan.maxPages,
+        signal: controller.signal,
+      })
+      if (controller.signal.aborted) return
+      const visibleScanResult = filterRejectedScanResult(scanResult, rejectedListingKeys)
+      setBinListings(scanResult.listings)
+      setBinScan(scanResult)
+      setBinError(binScanErrorSummary(scanResult))
+
+      let scanSalesCacheModels = activeSalesCacheModels
+      try {
+        const loadedSalesCacheModels = await loadSalesCacheModelsForListings(visibleScanResult.listings, controller.signal)
+        scanSalesCacheModels = { ...activeSalesCacheModels, ...loadedSalesCacheModels }
+      } catch {
+        scanSalesCacheModels = activeSalesCacheModels
+      }
+      if (controller.signal.aborted) return
+      void saveScoredLiveMarketSnapshot({
+        scanType: 'bin',
+        scanResult: visibleScanResult,
+        models: scanModels,
+        minPrice: binMinPrice,
+        playerScope: 'all',
+        playerNames: [],
+        searchMode: 'checklist',
+        searchTerm: 'authorized-fanatics-wide-feed',
+        salesCacheModels: scanSalesCacheModels,
+      })
+    } catch (scanError) {
+      if (controller.signal.aborted) return
+      setBinError(scanError instanceof Error ? scanError.message : 'Fanatics Collect wide scan failed')
+    } finally {
+      if (binRequestRef.current === controller) {
+        setBinLoading(false)
+        binRequestRef.current = null
+      }
+    }
   }
 
   async function saveScoredLiveMarketSnapshot(options: {
@@ -10263,6 +10422,7 @@ function App() {
         targetType: options.coverageTargetType ?? 'listing',
       })
       if (targets.length > 0) {
+        const scannedMarketplaces = scanCoverageMarketplaceHits(scanResult.listings).map((marketplace) => marketplace.marketplace)
         await saveScanCoverageRun({
           scanType: options.scanType,
           scanKey,
@@ -10274,7 +10434,7 @@ function App() {
           releaseScope: effectiveBinModelKey === BIN_ALL_MODELS_KEY ? 'all' : 'selected',
           observedAt: options.scanResult.fetchedAt,
           status: scanResult.errors.length > 0 ? 'partial' : 'complete',
-          marketplaces: ['ebay', 'fanatics-collect'],
+          marketplaces: scannedMarketplaces,
           request: {
             minPrice: options.minPrice,
             modelKeys: options.models.map(checklistModelKey),
@@ -10342,8 +10502,9 @@ function App() {
       return
     }
 
-    if (!ebayStatus?.configured) {
-      setBinError(ebayStatus?.message ?? 'Set EBAY_CLIENT_ID and EBAY_CLIENT_SECRET in .env.local')
+    const binProvidersConfigured = Boolean(ebayStatus?.configured || fanaticsStatus?.targetedSearch?.configured)
+    if (!binProvidersConfigured) {
+      setBinError(fanaticsStatus?.message ?? ebayStatus?.message ?? 'No authorized live-listing provider is configured.')
       return
     }
 
@@ -10417,10 +10578,13 @@ function App() {
             searchTerm: activeSearchTerm,
             signal: controller.signal,
           }
-          const providerScans = await Promise.allSettled([
-            fetchEbayBinListings(providerOptions),
-            fetchFanaticsCollectBinListings(providerOptions),
-          ])
+          const providers = [
+            ...(ebayStatus?.configured ? [{ label: 'eBay', run: () => fetchEbayBinListings(providerOptions) }] : []),
+            ...(fanaticsStatus?.targetedSearch?.configured
+              ? [{ label: 'Fanatics Collect', run: () => fetchFanaticsCollectBinListings(providerOptions) }]
+              : []),
+          ]
+          const providerScans = await Promise.allSettled(providers.map((provider) => provider.run()))
           const successfulProviderScans = providerScans.flatMap((providerResult) =>
             providerResult.status === 'fulfilled' ? [providerResult.value] : [],
           )
@@ -10428,13 +10592,11 @@ function App() {
             providerResult.status === 'rejected'
               ? [
                   {
-                    query: `${checklistModelLabel(model)} / ${providerIndex === 0 ? 'eBay' : 'Fanatics Collect'}`,
+                    query: `${checklistModelLabel(model)} / ${providers[providerIndex]?.label ?? 'marketplace'}`,
                     error:
                       providerResult.reason instanceof Error
                         ? providerResult.reason.message
-                        : providerIndex === 0
-                          ? 'eBay BIN scan failed'
-                          : 'Fanatics Collect scan failed',
+                        : `${providers[providerIndex]?.label ?? 'Marketplace'} BIN scan failed`,
                   },
                 ]
               : [],
@@ -10824,6 +10986,9 @@ function App() {
           pricedRows={matrix.totalPricedPlayers}
           topBase={topBase}
           dealCount={displayedBinOpportunities.length + displayedAuctionOpportunities.length}
+          fanaticsDealCount={displayedBinOpportunities.filter(
+            (opportunity) => opportunity.listing.marketplace === 'fanatics-collect' && opportunity.listing.allInPrice <= opportunity.fairValue,
+          ).length}
           listingCount={displayedLiveListingCount}
           modelReady={matrix.totalResolvedCells > 0}
         />
@@ -11118,6 +11283,15 @@ function App() {
             </aside>
           ) : null}
         </section>
+      ) : workMode === 'fanatics' ? (
+        <FanaticsCollectPage
+          opportunities={displayedBinOpportunities}
+          scan={binScan}
+          status={fanaticsStatus}
+          loading={binLoading}
+          error={binError}
+          onRunScan={() => void scanFanaticsCollectWide('fanatics')}
+        />
       ) : workMode === 'price' ? (
         <section className="price-workflow" aria-label="Price my card">
           <div className="price-workflow-shell">
@@ -11177,6 +11351,7 @@ function App() {
             scan={binScan}
             auctionScan={auctionScan}
             ebayStatus={ebayStatus}
+            fanaticsStatus={fanaticsStatus}
             loading={binLoading}
             auctionLoading={auctionLoading}
             modelLoading={checklistLoading}
@@ -11209,6 +11384,7 @@ function App() {
             onScanBaseAutos={scanBaseAutos}
             onScanLowSerial={scanLowSerialNonAutos}
             onScanSuperfractors={scanSuperfractors}
+            onScanFanaticsWide={() => void scanFanaticsCollectWide()}
             resultsRef={dealResultsRef}
           />
           <LiveMarketMap

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2575,10 +2575,10 @@ function WorkflowCommand({
     },
     {
       mode: 'fanatics' as const,
-      tier: 'secondary',
+      tier: 'primary',
       eyebrow: 'Collect',
       title: 'Fanatics Finds',
-      description: 'Prospect autos at model',
+      description: 'Cards within 50% of model',
       value: fanaticsDealCount.toLocaleString(),
       icon: <Store size={19} />,
     },
@@ -2611,10 +2611,10 @@ function WorkflowCommand({
     },
   ]
   const primaryMobileItems = navigationItems.filter((item) =>
-    ['lookup', 'deals', 'price'].includes(item.mode),
+    ['lookup', 'deals', 'fanatics', 'price'].includes(item.mode),
   )
   const secondaryMobileItems = navigationItems.filter((item) =>
-    ['fanatics', 'case-hits', 'wax', 'health'].includes(item.mode),
+    ['case-hits', 'wax', 'health'].includes(item.mode),
   )
   const secondaryModeActive = secondaryMobileItems.some((item) => item.mode === mode)
 
@@ -2700,7 +2700,7 @@ function WorkflowCommand({
             key={`mobile:${item.mode}`}
           >
             <span>{item.icon}</span>
-            <strong>{item.mode === 'lookup' ? 'Board' : item.mode === 'deals' ? 'Deals' : 'Price'}</strong>
+            <strong>{item.mode === 'lookup' ? 'Board' : item.mode === 'deals' ? 'Deals' : item.mode === 'fanatics' ? 'Fanatics' : 'Price'}</strong>
           </button>
         ))}
         <button

--- a/src/FanaticsCollectPage.css
+++ b/src/FanaticsCollectPage.css
@@ -1,0 +1,447 @@
+.fanatics-desk {
+  display: grid;
+  gap: 18px;
+}
+
+.fanatics-hero {
+  align-items: flex-end;
+  background:
+    radial-gradient(circle at 88% 10%, rgba(194, 255, 93, 0.18), transparent 28%),
+    linear-gradient(145deg, rgba(13, 35, 31, 0.98), rgba(5, 18, 18, 0.98));
+  border: 1px solid rgba(190, 255, 113, 0.2);
+  border-radius: 18px;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  overflow: hidden;
+  padding: 28px;
+}
+
+.fanatics-kicker {
+  align-items: center;
+  color: #c9ff77;
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  gap: 7px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.fanatics-hero h2 {
+  color: #f4f8ed;
+  font-size: clamp(1.55rem, 3vw, 2.5rem);
+  letter-spacing: -0.04em;
+  margin: 10px 0 8px;
+}
+
+.fanatics-hero p {
+  color: #a9bbb4;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 700px;
+}
+
+.fanatics-scan-button {
+  align-items: center;
+  background: #c9ff77;
+  border: 0;
+  border-radius: 12px;
+  color: #102019;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 850;
+  gap: 8px;
+  justify-content: center;
+  min-height: 46px;
+  min-width: 210px;
+  padding: 0 18px;
+}
+
+.fanatics-scan-button:disabled {
+  background: rgba(205, 221, 210, 0.12);
+  color: #80918a;
+  cursor: not-allowed;
+}
+
+.fanatics-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fanatics-summary span {
+  background: rgba(9, 27, 25, 0.84);
+  border: 1px solid rgba(164, 203, 180, 0.13);
+  border-radius: 999px;
+  color: #8fa49b;
+  font-size: 0.7rem;
+  padding: 7px 11px;
+}
+
+.fanatics-summary strong {
+  color: #e4eee7;
+  margin-right: 4px;
+}
+
+.fanatics-permission-note {
+  align-items: center;
+  background: rgba(8, 27, 24, 0.96);
+  border: 1px solid rgba(174, 196, 181, 0.18);
+  border-radius: 14px;
+  color: #aebfb7;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto 1fr auto;
+  padding: 15px 17px;
+}
+
+.fanatics-permission-note strong,
+.fanatics-permission-note span {
+  display: block;
+}
+
+.fanatics-permission-note strong {
+  color: #dce9e1;
+  margin-bottom: 3px;
+}
+
+.fanatics-permission-note span {
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.fanatics-permission-note a,
+.fanatics-card-footer a {
+  align-items: center;
+  color: #c9ff77;
+  display: inline-flex;
+  font-size: 0.74rem;
+  font-weight: 750;
+  gap: 5px;
+  text-decoration: none;
+}
+
+.fanatics-filter-bar {
+  align-items: end;
+  background: rgba(6, 20, 19, 0.95);
+  border: 1px solid rgba(174, 196, 181, 0.13);
+  border-radius: 16px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(230px, 1.7fr) repeat(4, minmax(120px, 0.65fr)) auto;
+  padding: 14px;
+}
+
+.fanatics-filter-bar label {
+  display: grid;
+  gap: 6px;
+}
+
+.fanatics-filter-bar label > span {
+  color: #7f958b;
+  font-size: 0.65rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.fanatics-filter-bar input,
+.fanatics-filter-bar select {
+  background: rgba(226, 239, 230, 0.055);
+  border: 1px solid rgba(174, 196, 181, 0.16);
+  border-radius: 10px;
+  color: #e5eee8;
+  font: inherit;
+  font-size: 0.78rem;
+  height: 42px;
+  min-width: 0;
+  padding: 0 11px;
+}
+
+.fanatics-search {
+  align-items: center;
+  background: rgba(226, 239, 230, 0.055);
+  border: 1px solid rgba(174, 196, 181, 0.16);
+  border-radius: 10px;
+  display: flex !important;
+  gap: 8px !important;
+  height: 40px;
+  padding: 0 11px;
+}
+
+.fanatics-search svg {
+  color: #789087;
+  flex: 0 0 auto;
+}
+
+.fanatics-search input {
+  background: transparent;
+  border: 0;
+  height: auto;
+  outline: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.hold-filter {
+  align-items: center;
+  background: rgba(226, 239, 230, 0.055);
+  border: 1px solid rgba(174, 196, 181, 0.16);
+  border-radius: 10px;
+  color: #a7b9b0;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 750;
+  gap: 7px;
+  height: 42px;
+  justify-content: center;
+  padding: 0 13px;
+}
+
+.hold-filter.active {
+  background: rgba(201, 255, 119, 0.13);
+  border-color: rgba(201, 255, 119, 0.35);
+  color: #c9ff77;
+}
+
+.hold-filter:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.fanatics-result-head {
+  align-items: end;
+  display: flex;
+  justify-content: space-between;
+}
+
+.fanatics-result-head span,
+.fanatics-result-head strong {
+  display: block;
+}
+
+.fanatics-result-head span {
+  color: #7f958b;
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.fanatics-result-head strong {
+  color: #17352d;
+  font-size: 1.25rem;
+  margin-top: 3px;
+}
+
+.fanatics-result-head small {
+  color: #536b61;
+  max-width: 520px;
+  text-align: right;
+}
+
+.fanatics-card-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.fanatics-card {
+  background: linear-gradient(165deg, rgba(13, 31, 29, 0.98), rgba(6, 19, 18, 0.98));
+  border: 1px solid rgba(174, 196, 181, 0.13);
+  border-radius: 15px;
+  display: grid;
+  gap: 15px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.fanatics-card-topline,
+.fanatics-card-footer {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.fanatics-value-chip {
+  background: rgba(201, 255, 119, 0.1);
+  border: 1px solid rgba(201, 255, 119, 0.22);
+  border-radius: 999px;
+  color: #c9ff77;
+  font-size: 0.65rem;
+  font-weight: 800;
+  padding: 5px 8px;
+}
+
+.fanatics-star {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: #667d73;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  padding: 3px;
+}
+
+.fanatics-star.active {
+  color: #c9ff77;
+}
+
+.fanatics-card-copy span {
+  color: #7f958b;
+  font-size: 0.66rem;
+}
+
+.fanatics-card-copy h3 {
+  color: #f0f5f1;
+  font-size: 1.12rem;
+  letter-spacing: -0.02em;
+  margin: 5px 0;
+}
+
+.fanatics-card-copy p {
+  color: #9badA4;
+  display: -webkit-box;
+  font-size: 0.74rem;
+  line-height: 1.45;
+  margin: 0;
+  min-height: 2.9em;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.fanatics-price-grid {
+  display: grid;
+  gap: 7px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.fanatics-price-grid span {
+  background: rgba(225, 238, 229, 0.04);
+  border-radius: 9px;
+  min-width: 0;
+  padding: 8px;
+}
+
+.fanatics-price-grid small,
+.fanatics-price-grid strong {
+  display: block;
+}
+
+.fanatics-price-grid small {
+  color: #6e8379;
+  font-size: 0.59rem;
+  margin-bottom: 3px;
+  text-transform: uppercase;
+}
+
+.fanatics-price-grid strong {
+  color: #dce8e0;
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fanatics-price-grid .positive strong {
+  color: #c9ff77;
+}
+
+.fanatics-card-footer {
+  border-top: 1px solid rgba(174, 196, 181, 0.09);
+  gap: 10px;
+  padding-top: 12px;
+}
+
+.fanatics-card-footer > span {
+  color: #6f847a;
+  font-size: 0.64rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fanatics-error,
+.fanatics-empty {
+  background: rgba(8, 27, 24, 0.96);
+  border: 1px solid rgba(164, 184, 170, 0.18);
+  border-radius: 14px;
+  color: #aebfb7;
+  padding: 18px;
+}
+
+.fanatics-empty {
+  align-items: center;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  min-height: 180px;
+  text-align: center;
+}
+
+.fanatics-empty strong {
+  color: #dbe7df;
+}
+
+.fanatics-empty span {
+  font-size: 0.76rem;
+}
+
+@media (max-width: 1120px) {
+  .fanatics-filter-bar {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .fanatics-search {
+    grid-column: span 2;
+  }
+
+  .fanatics-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .fanatics-hero {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 21px;
+  }
+
+  .fanatics-scan-button {
+    width: 100%;
+  }
+
+  .fanatics-permission-note {
+    grid-template-columns: auto 1fr;
+  }
+
+  .fanatics-permission-note a {
+    grid-column: 2;
+  }
+
+  .fanatics-filter-bar,
+  .fanatics-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fanatics-search {
+    grid-column: auto;
+  }
+
+  .fanatics-result-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .fanatics-result-head small {
+    text-align: left;
+  }
+}

--- a/src/FanaticsCollectPage.test.ts
+++ b/src/FanaticsCollectPage.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import type { Opportunity } from './types'
+import { filterFanaticsDealOpportunities, type FanaticsDealFilters } from './lib/fanaticsDealFilters'
+
+function opportunity(options: {
+  id: string
+  player: string
+  ask: number
+  fair: number
+  marketplace?: string
+  graded?: boolean
+  confidence?: number
+}): Opportunity {
+  const edge = options.fair - options.ask
+  return {
+    listing: {
+      id: options.id,
+      kind: 'bin',
+      title: `2026 Bowman Chrome ${options.player} 1st Auto`,
+      playerName: options.player,
+      currentPrice: options.ask,
+      shippingCost: 0,
+      allInPrice: options.ask,
+      marketPrice: 0,
+      compCount: 0,
+      comps: [],
+      status: 'active',
+      isSold: false,
+      marketplace: options.marketplace ?? 'fanatics-collect',
+      marketplaceLabel: 'Fanatics Collect',
+      watchCount: 0,
+      bidCount: 0,
+      releaseYear: 2026,
+      releaseLabel: '2026 Bowman',
+      variationLabel: 'Base Auto',
+      serialDenominator: null,
+      isGraded: Boolean(options.graded),
+      isEligibleGraded: Boolean(options.graded),
+      isBowman: true,
+      isAutograph: true,
+      isFirstBowman: true,
+      isTargetAuto: true,
+      isLowSerialNonAuto: false,
+      isHandSigned: false,
+      universeScore: 1,
+      listingAgeHours: 1,
+      hoursToClose: null,
+    },
+    score: 80,
+    grade: 'A',
+    action: 'Buy now',
+    lane: 'buy',
+    fairValue: options.fair,
+    rawFairValue: options.fair,
+    modelPrice: options.fair,
+    modelConfidence: options.confidence ?? 0.8,
+    valuationSource: 'base-auto',
+    discountPct: edge / options.fair,
+    edgeDollars: edge,
+    rawEdgeDollars: edge,
+    maxEntry: options.fair,
+    expectedRoiPct: edge / options.ask,
+    confidence: options.confidence ?? 0.8,
+    trustScore: 80,
+    compQualityScore: 75,
+    availabilityScore: 70,
+    universeScore: 1,
+    executionScore: 80,
+    liquidityScore: 70,
+    urgencyScore: 50,
+    riskScore: 10,
+    scoreComponents: {
+      rawEdge: 1,
+      percentEdge: 1,
+      compQuality: 1,
+      targetFit: 1,
+      availability: 1,
+      variationModel: 1,
+      prospect: 1,
+      riskPenalty: 0,
+    },
+    thesis: '',
+    tags: [],
+    reasons: [],
+    warnings: [],
+  }
+}
+
+const defaults: FanaticsDealFilters = {
+  query: '',
+  valueBand: 'fair-or-better',
+  grade: 'all',
+  sort: 'edge',
+  maxPrice: 0,
+  holdsOnly: false,
+  holdTargets: [],
+}
+
+describe('Fanatics Collect dedicated-page filters', () => {
+  it('defaults to Fanatics listings at or below model and sorts by dollar edge', () => {
+    const results = filterFanaticsDealOpportunities(
+      [
+        opportunity({ id: 'small', player: 'Player Small', ask: 80, fair: 100 }),
+        opportunity({ id: 'large', player: 'Player Large', ask: 150, fair: 250 }),
+        opportunity({ id: 'rich', player: 'Player Rich', ask: 120, fair: 100 }),
+        opportunity({ id: 'ebay', player: 'Player Ebay', ask: 10, fair: 200, marketplace: 'ebay' }),
+      ],
+      defaults,
+    )
+
+    expect(results.map((result) => result.listing.id)).toEqual(['large', 'small'])
+  })
+
+  it('supports near-model, player search, grade, max-price, and hold-target filters', () => {
+    const results = filterFanaticsDealOpportunities(
+      [
+        opportunity({ id: 'raw', player: 'Aiva Arquette', ask: 105, fair: 100 }),
+        opportunity({ id: 'graded', player: 'Aiva Arquette', ask: 95, fair: 100, graded: true }),
+        opportunity({ id: 'other', player: 'Luis Arana', ask: 75, fair: 100 }),
+      ],
+      {
+        ...defaults,
+        query: 'arquette',
+        valueBand: 'near-model',
+        grade: 'graded',
+        maxPrice: 100,
+        holdsOnly: true,
+        holdTargets: ['Aiva Arquette'],
+      },
+    )
+
+    expect(results.map((result) => result.listing.id)).toEqual(['graded'])
+  })
+
+  it('can sort by discount, lowest price, or confidence', () => {
+    const rows = [
+      opportunity({ id: 'confidence', player: 'Player A', ask: 90, fair: 100, confidence: 0.95 }),
+      opportunity({ id: 'discount', player: 'Player B', ask: 50, fair: 100, confidence: 0.7 }),
+      opportunity({ id: 'price', player: 'Player C', ask: 40, fair: 60, confidence: 0.8 }),
+    ]
+
+    expect(filterFanaticsDealOpportunities(rows, { ...defaults, sort: 'discount' })[0]?.listing.id).toBe('discount')
+    expect(filterFanaticsDealOpportunities(rows, { ...defaults, sort: 'price' })[0]?.listing.id).toBe('price')
+    expect(filterFanaticsDealOpportunities(rows, { ...defaults, sort: 'confidence' })[0]?.listing.id).toBe('confidence')
+  })
+})

--- a/src/FanaticsCollectPage.test.ts
+++ b/src/FanaticsCollectPage.test.ts
@@ -88,7 +88,7 @@ function opportunity(options: {
 
 const defaults: FanaticsDealFilters = {
   query: '',
-  valueBand: 'fair-or-better',
+  valueBand: 'within-50',
   grade: 'all',
   sort: 'edge',
   maxPrice: 0,
@@ -97,18 +97,19 @@ const defaults: FanaticsDealFilters = {
 }
 
 describe('Fanatics Collect dedicated-page filters', () => {
-  it('defaults to Fanatics listings at or below model and sorts by dollar edge', () => {
+  it('defaults to Fanatics listings within 50% of model and sorts by dollar edge', () => {
     const results = filterFanaticsDealOpportunities(
       [
         opportunity({ id: 'small', player: 'Player Small', ask: 80, fair: 100 }),
         opportunity({ id: 'large', player: 'Player Large', ask: 150, fair: 250 }),
         opportunity({ id: 'rich', player: 'Player Rich', ask: 120, fair: 100 }),
+        opportunity({ id: 'outside', player: 'Player Outside', ask: 151, fair: 100 }),
         opportunity({ id: 'ebay', player: 'Player Ebay', ask: 10, fair: 200, marketplace: 'ebay' }),
       ],
       defaults,
     )
 
-    expect(results.map((result) => result.listing.id)).toEqual(['large', 'small'])
+    expect(results.map((result) => result.listing.id)).toEqual(['large', 'small', 'rich'])
   })
 
   it('supports near-model, player search, grade, max-price, and hold-target filters', () => {

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -50,6 +50,7 @@ function valueLabel(opportunity: Opportunity) {
   if (ratio <= 0.8) return 'Strong value'
   if (ratio <= 1) return 'Fair or better'
   if (ratio <= 1.15) return 'Near model'
+  if (ratio <= 1.5) return 'Within 50%'
   return 'Above model'
 }
 
@@ -69,7 +70,7 @@ export function FanaticsCollectPage({
   onRunScan: () => void
 }) {
   const [query, setQuery] = useState('')
-  const [valueBand, setValueBand] = useState<FanaticsValueBand>('fair-or-better')
+  const [valueBand, setValueBand] = useState<FanaticsValueBand>('within-50')
   const [grade, setGrade] = useState<FanaticsGradeFilter>('all')
   const [sort, setSort] = useState<FanaticsDealSort>('edge')
   const [maxPrice, setMaxPrice] = useState(0)
@@ -94,8 +95,8 @@ export function FanaticsCollectPage({
     [fanaticsOpportunities, grade, holdTargets, holdsOnly, maxPrice, query, sort, valueBand],
   )
   const holdKeys = useMemo(() => new Set(holdTargets.map(fanaticsPlayerKey)), [holdTargets])
-  const fairlyPricedCount = fanaticsOpportunities.filter(
-    (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue,
+  const withinModelWindowCount = fanaticsOpportunities.filter(
+    (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue * 1.5,
   ).length
   const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'No authorized scan yet'
 
@@ -118,7 +119,7 @@ export function FanaticsCollectPage({
             Fanatics Collect · Bowman prospect autos
           </span>
           <h2>Collect finds, without the clunky hunt.</h2>
-          <p>Search the full authorized feed, keep fairly priced cards in view, and save the players you want to hold.</p>
+          <p>See every matched card within 50% of model, then narrow the board or save the players you want to hold.</p>
         </div>
         <button className="fanatics-scan-button" type="button" onClick={onRunScan} disabled={!authorized || loading}>
           <RefreshCw size={17} className={loading ? 'spin' : undefined} />
@@ -128,7 +129,7 @@ export function FanaticsCollectPage({
 
       <div className="fanatics-summary" aria-label="Fanatics scan summary">
         <span><strong>{fanaticsOpportunities.length.toLocaleString()}</strong> modeled listings</span>
-        <span><strong>{fairlyPricedCount.toLocaleString()}</strong> fair or better</span>
+        <span><strong>{withinModelWindowCount.toLocaleString()}</strong> within 50% of model</span>
         <span><strong>{holdTargets.length.toLocaleString()}</strong> hold targets</span>
         <span><strong>{scan?.stats.upstreamPagesFetched.toLocaleString() ?? '0'}</strong> feed pages</span>
         <span>{latestLabel}</span>
@@ -158,6 +159,7 @@ export function FanaticsCollectPage({
         <label>
           <span>Value</span>
           <select value={valueBand} onChange={(event) => setValueBand(event.target.value as FanaticsValueBand)}>
+            <option value="within-50">Within 50% of model</option>
             <option value="fair-or-better">Fair or better</option>
             <option value="near-model">Within 15% of model</option>
             <option value="all">All modeled listings</option>
@@ -217,7 +219,7 @@ export function FanaticsCollectPage({
         <div className="fanatics-empty">
           <Target size={25} />
           <strong>{scan ? 'No cards match these filters.' : 'Run the authorized wide scan to build this board.'}</strong>
-          <span>{scan ? 'Try near-model, remove the price cap, or search another player.' : 'Then star any player to create your personal hold-target view.'}</span>
+          <span>{scan ? 'Try the all-listings view, remove the price cap, or search another player.' : 'Then star any player to create your personal hold-target view.'}</span>
         </div>
       ) : (
         <div className="fanatics-card-grid">

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -1,0 +1,267 @@
+import { ExternalLink, RefreshCw, Search, ShieldCheck, Star, Target } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { EbayBinScanResult } from './lib/ebay'
+import type { FanaticsCollectStatus } from './lib/fanaticsCollect'
+import {
+  fanaticsPlayerKey,
+  filterFanaticsDealOpportunities,
+  type FanaticsDealSort,
+  type FanaticsGradeFilter,
+  type FanaticsValueBand,
+} from './lib/fanaticsDealFilters'
+import type { Opportunity } from './types'
+import './FanaticsCollectPage.css'
+
+const HOLD_TARGETS_KEY = 'backstop:fanatics-hold-targets:v1'
+
+function money(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value)
+}
+
+function percent(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function readHoldTargets() {
+  if (typeof window === 'undefined') return [] as string[]
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(HOLD_TARGETS_KEY) ?? '[]') as unknown
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string' && Boolean(value.trim())) : []
+  } catch {
+    return []
+  }
+}
+
+function writeHoldTargets(targets: string[]) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(HOLD_TARGETS_KEY, JSON.stringify(targets))
+  } catch {
+    // The page still works for this session when storage is unavailable.
+  }
+}
+
+function valueLabel(opportunity: Opportunity) {
+  const ratio = opportunity.listing.allInPrice / Math.max(opportunity.fairValue, 1)
+  if (ratio <= 0.8) return 'Strong value'
+  if (ratio <= 1) return 'Fair or better'
+  if (ratio <= 1.15) return 'Near model'
+  return 'Above model'
+}
+
+export function FanaticsCollectPage({
+  opportunities,
+  scan,
+  status,
+  loading,
+  error,
+  onRunScan,
+}: {
+  opportunities: Opportunity[]
+  scan: EbayBinScanResult | null
+  status: FanaticsCollectStatus | null
+  loading: boolean
+  error: string | null
+  onRunScan: () => void
+}) {
+  const [query, setQuery] = useState('')
+  const [valueBand, setValueBand] = useState<FanaticsValueBand>('fair-or-better')
+  const [grade, setGrade] = useState<FanaticsGradeFilter>('all')
+  const [sort, setSort] = useState<FanaticsDealSort>('edge')
+  const [maxPrice, setMaxPrice] = useState(0)
+  const [holdsOnly, setHoldsOnly] = useState(false)
+  const [holdTargets, setHoldTargets] = useState<string[]>(readHoldTargets)
+  const authorized = Boolean(status?.wideScan?.configured)
+  const fanaticsOpportunities = useMemo(
+    () => opportunities.filter((opportunity) => opportunity.listing.marketplace === 'fanatics-collect'),
+    [opportunities],
+  )
+  const filtered = useMemo(
+    () =>
+      filterFanaticsDealOpportunities(fanaticsOpportunities, {
+        query,
+        valueBand,
+        grade,
+        sort,
+        maxPrice,
+        holdsOnly,
+        holdTargets,
+      }),
+    [fanaticsOpportunities, grade, holdTargets, holdsOnly, maxPrice, query, sort, valueBand],
+  )
+  const holdKeys = useMemo(() => new Set(holdTargets.map(fanaticsPlayerKey)), [holdTargets])
+  const fairlyPricedCount = fanaticsOpportunities.filter(
+    (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue,
+  ).length
+  const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'No authorized scan yet'
+
+  const toggleHoldTarget = (playerName: string) => {
+    const playerKey = fanaticsPlayerKey(playerName)
+    const next = holdKeys.has(playerKey)
+      ? holdTargets.filter((target) => fanaticsPlayerKey(target) !== playerKey)
+      : [...holdTargets, playerName].sort((left, right) => left.localeCompare(right))
+    setHoldTargets(next)
+    writeHoldTargets(next)
+    if (next.length === 0) setHoldsOnly(false)
+  }
+
+  return (
+    <section className="fanatics-desk" aria-label="Fanatics Collect Bowman prospect auto finder">
+      <header className="fanatics-hero">
+        <div>
+          <span className="fanatics-kicker">
+            <Target size={15} />
+            Fanatics Collect · Bowman prospect autos
+          </span>
+          <h2>Collect finds, without the clunky hunt.</h2>
+          <p>Search the full authorized feed, keep fairly priced cards in view, and save the players you want to hold.</p>
+        </div>
+        <button className="fanatics-scan-button" type="button" onClick={onRunScan} disabled={!authorized || loading}>
+          <RefreshCw size={17} className={loading ? 'spin' : undefined} />
+          {loading ? 'Scanning Fanatics' : authorized ? 'Run wide Fanatics scan' : 'Approved feed required'}
+        </button>
+      </header>
+
+      <div className="fanatics-summary" aria-label="Fanatics scan summary">
+        <span><strong>{fanaticsOpportunities.length.toLocaleString()}</strong> modeled listings</span>
+        <span><strong>{fairlyPricedCount.toLocaleString()}</strong> fair or better</span>
+        <span><strong>{holdTargets.length.toLocaleString()}</strong> hold targets</span>
+        <span><strong>{scan?.stats.upstreamPagesFetched.toLocaleString() ?? '0'}</strong> feed pages</span>
+        <span>{latestLabel}</span>
+      </div>
+
+      {!authorized ? (
+        <div className="fanatics-permission-note">
+          <ShieldCheck size={18} />
+          <div>
+            <strong>Ready for an approved Fanatics feed.</strong>
+            <span>{status?.wideScan?.message ?? 'Written data-access permission is required before automated retrieval can run.'}</span>
+          </div>
+          <a href={status?.termsUrl} target="_blank" rel="noreferrer">Review terms <ExternalLink size={13} /></a>
+        </div>
+      ) : null}
+
+      <div className="fanatics-filter-bar" aria-label="Fanatics listing filters">
+        <label className="fanatics-search">
+          <Search size={17} />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search player, set, or parallel"
+            aria-label="Search Fanatics prospect autos"
+          />
+        </label>
+        <label>
+          <span>Value</span>
+          <select value={valueBand} onChange={(event) => setValueBand(event.target.value as FanaticsValueBand)}>
+            <option value="fair-or-better">Fair or better</option>
+            <option value="near-model">Within 15% of model</option>
+            <option value="all">All modeled listings</option>
+          </select>
+        </label>
+        <label>
+          <span>Card</span>
+          <select value={grade} onChange={(event) => setGrade(event.target.value as FanaticsGradeFilter)}>
+            <option value="all">Raw + graded</option>
+            <option value="raw">Raw only</option>
+            <option value="graded">Graded only</option>
+          </select>
+        </label>
+        <label>
+          <span>Sort</span>
+          <select value={sort} onChange={(event) => setSort(event.target.value as FanaticsDealSort)}>
+            <option value="edge">Biggest $ edge</option>
+            <option value="discount">Best discount</option>
+            <option value="price">Lowest price</option>
+            <option value="confidence">Highest confidence</option>
+          </select>
+        </label>
+        <label>
+          <span>Max ask</span>
+          <input
+            type="number"
+            min="0"
+            step="25"
+            value={maxPrice || ''}
+            placeholder="No max"
+            onChange={(event) => setMaxPrice(Math.max(0, Number(event.target.value) || 0))}
+            aria-label="Maximum Fanatics ask price"
+          />
+        </label>
+        <button
+          className={holdsOnly ? 'hold-filter active' : 'hold-filter'}
+          type="button"
+          onClick={() => setHoldsOnly((current) => !current)}
+          disabled={holdTargets.length === 0}
+        >
+          <Star size={15} fill={holdsOnly ? 'currentColor' : 'none'} />
+          My hold targets
+        </button>
+      </div>
+
+      <div className="fanatics-result-head">
+        <div>
+          <span>Prospect auto board</span>
+          <strong>{filtered.length.toLocaleString()} cards</strong>
+        </div>
+        <small>Edges compare the visible ask with Backstop model value; shipping and tax may be additional.</small>
+      </div>
+
+      {error ? <div className="fanatics-error" role="alert">{error}</div> : null}
+
+      {filtered.length === 0 ? (
+        <div className="fanatics-empty">
+          <Target size={25} />
+          <strong>{scan ? 'No cards match these filters.' : 'Run the authorized wide scan to build this board.'}</strong>
+          <span>{scan ? 'Try near-model, remove the price cap, or search another player.' : 'Then star any player to create your personal hold-target view.'}</span>
+        </div>
+      ) : (
+        <div className="fanatics-card-grid">
+          {filtered.map((opportunity) => {
+            const player = opportunity.listing.playerName
+            const isHold = holdKeys.has(fanaticsPlayerKey(player))
+            return (
+              <article className="fanatics-card" key={opportunity.listing.id}>
+                <div className="fanatics-card-topline">
+                  <span className="fanatics-value-chip">{valueLabel(opportunity)}</span>
+                  <button
+                    type="button"
+                    className={isHold ? 'fanatics-star active' : 'fanatics-star'}
+                    onClick={() => toggleHoldTarget(player)}
+                    aria-label={isHold ? `Remove ${player} from hold targets` : `Add ${player} to hold targets`}
+                    title={isHold ? 'Remove hold target' : 'Save as hold target'}
+                  >
+                    <Star size={16} fill={isHold ? 'currentColor' : 'none'} />
+                  </button>
+                </div>
+                <div className="fanatics-card-copy">
+                  <span>{opportunity.listing.releaseLabel} · {opportunity.matchedVariation ?? opportunity.listing.variationLabel}</span>
+                  <h3>{player}</h3>
+                  <p>{opportunity.listing.title}</p>
+                </div>
+                <div className="fanatics-price-grid">
+                  <span><small>Ask</small><strong>{money(opportunity.listing.allInPrice)}</strong></span>
+                  <span><small>Model</small><strong>{money(opportunity.fairValue)}</strong></span>
+                  <span className={opportunity.edgeDollars >= 0 ? 'positive' : ''}>
+                    <small>Difference</small><strong>{money(opportunity.edgeDollars)}</strong>
+                  </span>
+                  <span><small>Discount</small><strong>{percent(opportunity.discountPct)}</strong></span>
+                </div>
+                <div className="fanatics-card-footer">
+                  <span>{Math.round(opportunity.confidence * 100)}% confidence · {opportunity.valuationSource.replace(/-/g, ' ')}</span>
+                  <a href={opportunity.listing.listingUrl || undefined} target="_blank" rel="noreferrer">
+                    View on Collect <ExternalLink size={13} />
+                  </a>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/fanaticsCollect.test.ts
+++ b/src/lib/fanaticsCollect.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import type { ChecklistModel } from '../types'
+import { mapAuthorizedFanaticsCollectInventory } from './fanaticsCollect'
+
+function model(
+  release: string,
+  releaseYear: number,
+  category: ChecklistModel['category'],
+  players: string[],
+): ChecklistModel {
+  return {
+    release,
+    releaseYear,
+    category,
+    fetchedAt: '2026-07-11T12:00:00.000Z',
+    source: 'canonical-sold-model',
+    multipliers: [{ variation: 'Gold Refractor Auto /50', avgMultiplier: 4 }],
+    players: players.map((playerName) => ({
+      playerName,
+      baseAvgPrice: 100,
+      baseSalesCount: 5,
+      variations: [],
+    })),
+  }
+}
+
+const bowman2026 = model('2026-Bowman', 2026, 'bowman', ['Aiva Arquette', 'Luis Arana'])
+const chrome2025 = model('2025-Bowman-Chrome', 2025, 'chrome', ['Aiva Arquette', 'Jesus Made'])
+const draft2025 = model('2025-Bowman-Draft', 2025, 'draft', ['Eli Willits'])
+
+describe('authorized Fanatics Collect inventory matcher', () => {
+  it('maps an active fixed-price Bowman auto to one checklist model with a namespaced identity', () => {
+    const result = mapAuthorizedFanaticsCollectInventory(
+      [{
+        listingUuid: 'listing-one',
+        title: '2026 Bowman Chrome Aiva Arquette 1st Gold Refractor Auto /50',
+        askingPrice: 240,
+        marketplace: 'FIXED',
+        status: 'Live',
+        year: 2026,
+        allowOffers: true,
+        gradingService: 'PSA',
+        grade: 10,
+        listedAt: 1_783_331_334,
+      }],
+      [bowman2026, chrome2025, draft2025],
+    )
+
+    expect(result.stats.mappedListings).toBe(1)
+    expect(result.listings[0]).toMatchObject({
+      item_id: 'fanatics-collect:listing-one',
+      player_name: 'Aiva Arquette',
+      current_price: 240,
+      shipping_cost: null,
+      release_year: 2026,
+      release: '2026-Bowman',
+      marketplace: 'fanatics-collect',
+      is_graded: true,
+      grader: 'PSA',
+      grade: 10,
+    })
+    expect(result.listings[0]?.listed_at).toMatch(/^2026-/)
+  })
+
+  it('fails closed for wrong years, adjacent products, non-autos, and non-fixed listings', () => {
+    const result = mapAuthorizedFanaticsCollectInventory(
+      [
+        { listingUuid: 'wrong-year', title: '2025 Bowman Chrome Luis Arana Auto', year: 2024, askingPrice: 25 },
+        { listingUuid: 'sapphire', title: '2026 Bowman Chrome Sapphire Aiva Arquette Auto', year: 2026, askingPrice: 25 },
+        { listingUuid: 'non-auto', title: '2026 Bowman Chrome Aiva Arquette Gold /50', year: 2026, askingPrice: 25 },
+        { listingUuid: 'auction', title: '2026 Bowman Chrome Aiva Arquette Auto', year: 2026, askingPrice: 25, saleType: 'WEEKLY' },
+      ],
+      [bowman2026, chrome2025],
+    )
+
+    expect(result.listings).toEqual([])
+    expect(result.stats).toMatchObject({
+      rejectedModel: 1,
+      rejectedTitleGuard: 1,
+      rejectedNonAuto: 1,
+      rejectedSaleType: 1,
+    })
+  })
+
+  it('rejects a same-player same-year release ambiguity unless structured release evidence resolves it', () => {
+    const flagship2025 = model('2025-Bowman', 2025, 'bowman', ['Shared Player'])
+    const chromeRelease2025 = model('2025-Bowman-Chrome', 2025, 'chrome', ['Shared Player'])
+    const ambiguous = {
+      listingUuid: 'ambiguous',
+      title: '2025 Bowman Chrome Shared Player 1st Auto',
+      year: 2025,
+      askingPrice: 100,
+    }
+
+    const unresolved = mapAuthorizedFanaticsCollectInventory([ambiguous], [flagship2025, chromeRelease2025])
+    expect(unresolved.listings).toEqual([])
+    expect(unresolved.stats.rejectedAmbiguousModel).toBe(1)
+
+    const resolved = mapAuthorizedFanaticsCollectInventory(
+      [{ ...ambiguous, listingUuid: 'resolved', release: '2025 Bowman Chrome' }],
+      [flagship2025, chromeRelease2025],
+    )
+    expect(resolved.listings).toHaveLength(1)
+    expect(resolved.listings[0]?.release).toBe('2025-Bowman-Chrome')
+  })
+
+  it('deduplicates only identical listing IDs and keeps distinct copies of the same card', () => {
+    const item = {
+      title: '2026 Bowman Chrome Luis Arana 1st Auto',
+      year: 2026,
+      askingPrice: 80,
+      status: 'active',
+      marketplace: 'fixed',
+    }
+    const result = mapAuthorizedFanaticsCollectInventory(
+      [
+        { ...item, listingUuid: 'copy-one' },
+        { ...item, listingUuid: 'copy-one' },
+        { ...item, listingUuid: 'copy-two' },
+      ],
+      [bowman2026],
+    )
+
+    expect(result.listings.map((listing) => listing.item_id)).toEqual([
+      'fanatics-collect:copy-one',
+      'fanatics-collect:copy-two',
+    ])
+  })
+})

--- a/src/lib/fanaticsCollect.ts
+++ b/src/lib/fanaticsCollect.ts
@@ -4,6 +4,7 @@ import {
   normalizedTitleKey,
   superfractorVariationLabel,
   titleEligibleForBowmanChromeAutoModel,
+  titleLooksLikeAutograph,
   titleLooksLikeBaseAuto,
   titleLooksLikeLowSerialNonAuto,
   titleLooksLikeSuperfractor,
@@ -30,13 +31,21 @@ type FanaticsCollectQueryMeta = {
   serialDenominator?: number
 }
 
-type FanaticsCollectHit = {
+export type FanaticsCollectHit = {
   objectID?: string
+  id?: string
   title?: string
   listingUuid?: string
+  listingId?: string
+  listing_id?: string
   slug?: string
+  url?: string
+  listingUrl?: string
+  listing_url?: string
   marketplace?: string
   marketplaceSource?: string
+  saleType?: string
+  sale_type?: string
   status?: string
   askingPrice?: number | string | null
   currentPrice?: number | string | null
@@ -46,6 +55,31 @@ type FanaticsCollectHit = {
   images?: unknown
   allowOffers?: boolean
   quantityAvailable?: number
+  year?: number | string | null
+  releaseYear?: number | string | null
+  release_year?: number | string | null
+  release?: string | null
+  setName?: string | null
+  set_name?: string | null
+  product?: string | null
+  productName?: string | null
+  product_name?: string | null
+  productTitle?: string | null
+  categoryParent?: string | string[] | null
+  subCategory1?: string | string[] | null
+  cardNumber?: string | null
+  card_number?: string | null
+  serial?: string | number | null
+  gradingService?: string | null
+  grading_service?: string | null
+  grader?: string | null
+  grade?: number | string | null
+  listedAt?: number | string | null
+  listed_at?: number | string | null
+  updatedAt?: number | string | null
+  updated_at?: number | string | null
+  sellerName?: string | null
+  seller_name?: string | null
   _backstopQuery?: FanaticsCollectQueryMeta
 }
 
@@ -55,6 +89,79 @@ type FanaticsCollectSearchResponse = {
   fetchedAt?: string
   stats?: Omit<EbayBinScanResult['stats'], 'mappedListings' | 'rejectedPlayerMismatches'>
   error?: string
+}
+
+export type FanaticsCollectStatus = {
+  provider: 'fanatics-collect'
+  label: string
+  configured: boolean
+  reachable: boolean
+  mode: 'disabled' | 'authorized-targeted-search'
+  marketplaceUrl: string
+  termsUrl: string
+  authorization?: {
+    configured: boolean
+    authorizationId?: string | null
+  }
+  targetedSearch?: {
+    configured: boolean
+    reachable: boolean
+  }
+  wideScan?: {
+    configured: boolean
+    mode: 'disabled' | 'authorized-feed'
+    imageRights: boolean
+    maxPages: number
+    message: string
+  }
+  message: string
+}
+
+type FanaticsCollectWideSearchResponse = FanaticsCollectSearchResponse & {
+  provenance?: {
+    mode?: string
+    authorizationId?: string
+    imageRights?: boolean
+  }
+  coverage?: {
+    complete?: boolean
+    stoppedReason?: string
+    nextCursor?: string | null
+    pageSize?: number
+    maxPages?: number
+    pagesFetched?: number
+    durationMs?: number
+  }
+}
+
+export type FanaticsCollectWideMatchStats = {
+  inputItems: number
+  mappedListings: number
+  rejectedInactive: number
+  rejectedSaleType: number
+  rejectedNonBowman: number
+  rejectedNonAuto: number
+  rejectedPrice: number
+  rejectedYear: number
+  rejectedPlayer: number
+  rejectedAmbiguousPlayer: number
+  rejectedModel: number
+  rejectedAmbiguousModel: number
+  rejectedTitleGuard: number
+}
+
+export type FanaticsCollectWideScanResult = EbayBinScanResult & {
+  coverage: {
+    complete: boolean
+    stoppedReason: string
+    pagesFetched: number
+    durationMs: number
+  }
+  matchStats: FanaticsCollectWideMatchStats
+  provenance: {
+    mode: string
+    authorizationId: string | null
+  }
 }
 
 type FetchFanaticsCollectListingsOptions = {
@@ -188,7 +295,7 @@ function slugFromTitle(title: string) {
 }
 
 function listingUuid(item: FanaticsCollectHit) {
-  const explicit = firstString([item.listingUuid])
+  const explicit = firstString([item.listingUuid, item.listingId, item.listing_id, item.id])
   if (explicit) return explicit
   const objectId = firstString([item.objectID])
   const match = objectId.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)
@@ -196,10 +303,51 @@ function listingUuid(item: FanaticsCollectHit) {
 }
 
 function fanaticsCollectListingUrl(item: FanaticsCollectHit, title: string) {
+  const explicitUrl = firstString([item.listingUrl, item.listing_url, item.url])
+  if (/^https:\/\/(?:www\.)?fanaticscollect\.com\//i.test(explicitUrl)) return explicitUrl
   const uuid = listingUuid(item)
   if (!uuid) return 'https://www.fanaticscollect.com/marketplace?type=FIXED'
   const slug = firstString([item.slug], slugFromTitle(title))
   return `https://www.fanaticscollect.com/buy-now/${uuid}/${slug || slugFromTitle(title)}`
+}
+
+function fanaticsCollectTimestamp(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const milliseconds = value < 10_000_000_000 ? value * 1_000 : value
+    const date = new Date(milliseconds)
+    return Number.isNaN(date.getTime()) ? null : date.toISOString()
+  }
+  if (typeof value !== 'string' || !value.trim()) return null
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) return fanaticsCollectTimestamp(numeric)
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function fanaticsCollectReleaseYear(item: FanaticsCollectHit, title: string) {
+  const explicit = numberValue(item.year ?? item.releaseYear ?? item.release_year, 0)
+  if (explicit >= 1900 && explicit <= 2100) return explicit
+  const titleYear = title.match(/\b(19\d{2}|20\d{2})\b/)
+  return titleYear ? Number(titleYear[1]) : null
+}
+
+function fanaticsCollectIsActive(item: FanaticsCollectHit) {
+  const status = firstString([item.status]).toLowerCase()
+  return !status || /^(live|active|available)$/.test(status)
+}
+
+function fanaticsCollectIsFixedPrice(item: FanaticsCollectHit) {
+  const saleType = firstString([item.saleType, item.sale_type, item.marketplace]).toLowerCase()
+  return !saleType || /^(fixed|buy.?now|bin)$/.test(saleType)
+}
+
+function fanaticsCollectCategoryMatches(title: string, category?: ChecklistModel['category']) {
+  if (!category) return true
+  const isDraft = /\bbowman(?:\s+chrome)?\s+draft\b|\bdraft\b/i.test(title)
+  if (category === 'draft') return isDraft
+  if (isDraft) return false
+  if (category === 'chrome') return /\bbowman\s+chrome\b/i.test(title)
+  return /\bbowman\b/i.test(title)
 }
 
 function imageUrlFrom(value: unknown): string {
@@ -233,6 +381,10 @@ function mapFanaticsCollectHitToListing(item: FanaticsCollectHit, fallbackReleas
   const playerName = firstString([meta?.playerName])
   const title = firstString([item.title])
   if (!playerName || !title || !titleMatchesPlayerName(title, playerName)) return null
+  if (!fanaticsCollectIsActive(item) || !fanaticsCollectIsFixedPrice(item)) return null
+  const releaseYear = fanaticsCollectReleaseYear(item, title)
+  if (meta?.releaseYear && releaseYear !== meta.releaseYear) return null
+  if (!fanaticsCollectCategoryMatches(title, meta?.category)) return null
   if (!titleMatchesVariationTerm(title, meta?.variationTerm)) return null
   if (meta?.superfractorOnly) {
     if (!titleLooksLikeSuperfractor(title)) return null
@@ -240,6 +392,7 @@ function mapFanaticsCollectHitToListing(item: FanaticsCollectHit, fallbackReleas
     if (!titleLooksLikeLowSerialNonAuto(title)) return null
   } else {
     if (meta?.baseAutoOnly && !titleLooksLikeBaseAuto(title)) return null
+    if (!titleLooksLikeAutograph(title)) return null
     if (!titleEligibleForBowmanChromeAutoModel(title)) return null
   }
 
@@ -263,18 +416,21 @@ function mapFanaticsCollectHitToListing(item: FanaticsCollectHit, fallbackReleas
   const uuid = listingUuid(item)
 
   return {
-    item_id: uuid || firstString([item.objectID], title),
+    item_id: `fanatics-collect:${uuid || firstString([item.objectID, item.id], title)}`,
     player_name: playerName,
     title,
     current_price: price,
-    shipping_cost: 0,
+    shipping_cost: null,
     buying_format: 'Buy It Now',
     listing_status: 'active',
     listing_url: fanaticsCollectListingUrl(item, title),
     marketplace: 'fanatics-collect',
     marketplace_label: 'Fanatics Collect',
     image_url: imageUrlFrom(item.imageSets) || imageUrlFrom(item.images),
-    release_year: meta?.releaseYear ?? null,
+    created_at: fanaticsCollectTimestamp(item.listedAt ?? item.listed_at),
+    listed_at: fanaticsCollectTimestamp(item.listedAt ?? item.listed_at),
+    seller_username: firstString([item.sellerName, item.seller_name]) || null,
+    release_year: releaseYear,
     product_type: meta?.superfractorOnly ? 'Bowman Superfractor' : fallbackReleaseLabel,
     release: meta?.release ?? fallbackReleaseLabel,
     variation: inferredVariation,
@@ -282,6 +438,9 @@ function mapFanaticsCollectHitToListing(item: FanaticsCollectHit, fallbackReleas
     is_hand_signed: isHandSigned,
     checklist_match: true,
     checklist_first_bowman: meta?.superfractorOnly ? /\b(1st|first)\b/i.test(title) : !meta?.lowSerialNonAuto,
+    is_graded: Boolean(firstString([item.gradingService, item.grading_service, item.grader]) || item.grade),
+    grader: firstString([item.gradingService, item.grading_service, item.grader]) || null,
+    grade: item.grade ?? null,
     comps: [],
     prospect: {
       name: playerName,
@@ -308,6 +467,275 @@ function dedupeListings(listings: MarketplaceListing[]) {
     deduped.push(listing)
   }
   return deduped
+}
+
+type FanaticsWideCandidate = {
+  model: ChecklistModel
+  playerName: string
+  playerKey: string
+}
+
+function emptyWideMatchStats(inputItems: number): FanaticsCollectWideMatchStats {
+  return {
+    inputItems,
+    mappedListings: 0,
+    rejectedInactive: 0,
+    rejectedSaleType: 0,
+    rejectedNonBowman: 0,
+    rejectedNonAuto: 0,
+    rejectedPrice: 0,
+    rejectedYear: 0,
+    rejectedPlayer: 0,
+    rejectedAmbiguousPlayer: 0,
+    rejectedModel: 0,
+    rejectedAmbiguousModel: 0,
+    rejectedTitleGuard: 0,
+  }
+}
+
+function fanaticsCollectExplicitRelease(item: FanaticsCollectHit) {
+  return firstString([
+    item.release,
+    item.setName,
+    item.set_name,
+    item.product,
+    item.productName,
+    item.product_name,
+  ])
+}
+
+function fanaticsCollectModelReleaseKey(model: ChecklistModel) {
+  return normalizedTitleKey(`${model.releaseYear} ${model.release.replace(/[-_]+/g, ' ')}`)
+}
+
+function explicitReleaseMatchesModel(explicitRelease: string, model: ChecklistModel) {
+  if (!explicitRelease) return false
+  const explicit = normalizedTitleKey(explicitRelease)
+  const modelKey = fanaticsCollectModelReleaseKey(model)
+  if (explicit === modelKey) return true
+  const hasYear = explicit.includes(String(model.releaseYear))
+  if (!hasYear) return false
+  if (model.category === 'draft') return /\bdraft\b/.test(explicit)
+  if (model.category === 'chrome') return /\bchrome\b/.test(explicit) && !/\bdraft\b/.test(explicit)
+  return /\bbowman\b/.test(explicit) && !/\b(?:chrome|draft)\b/.test(explicit)
+}
+
+function fanaticsCollectWideCandidates(models: ChecklistModel[]) {
+  const byYear = new Map<number, FanaticsWideCandidate[]>()
+  for (const model of models) {
+    for (const player of model.players) {
+      const playerKey = normalizedTitleKey(player.playerName)
+      if (!playerKey) continue
+      const candidates = byYear.get(model.releaseYear) ?? []
+      candidates.push({ model, playerName: player.playerName, playerKey })
+      byYear.set(model.releaseYear, candidates)
+    }
+  }
+  return byYear
+}
+
+function uniquePlayerMatches(title: string, candidates: FanaticsWideCandidate[]) {
+  const byPlayer = new Map<string, FanaticsWideCandidate[]>()
+  for (const candidate of candidates) {
+    if (!titleMatchesPlayerName(title, candidate.playerName)) continue
+    const current = byPlayer.get(candidate.playerKey) ?? []
+    current.push(candidate)
+    byPlayer.set(candidate.playerKey, current)
+  }
+  const matches = [...byPlayer.entries()]
+    .map(([playerKey, playerCandidates]) => ({ playerKey, candidates: playerCandidates }))
+    .sort(
+      (left, right) =>
+        right.playerKey.split(' ').length - left.playerKey.split(' ').length ||
+        right.playerKey.length - left.playerKey.length,
+    )
+  const best = matches[0]
+  if (!best) return { candidates: [] as FanaticsWideCandidate[], ambiguous: false }
+  const bestWords = best.playerKey.split(' ').length
+  const bestLength = best.playerKey.length
+  const equallySpecific = matches.filter(
+    (match) => match.playerKey.split(' ').length === bestWords && match.playerKey.length === bestLength,
+  )
+  return {
+    candidates: best.candidates,
+    ambiguous: equallySpecific.length > 1,
+  }
+}
+
+function categoryNarrowedCandidates(title: string, candidates: FanaticsWideCandidate[]) {
+  const isDraft = /\bdraft\b/i.test(title)
+  if (isDraft) return candidates.filter((candidate) => candidate.model.category === 'draft')
+  return candidates.filter((candidate) => candidate.model.category !== 'draft')
+}
+
+function resolveFanaticsCollectWideCandidate(item: FanaticsCollectHit, modelsByYear: Map<number, FanaticsWideCandidate[]>) {
+  const title = firstString([item.title, item.productTitle])
+  const year = fanaticsCollectReleaseYear(item, title)
+  if (!year) return { code: 'year' as const }
+  const yearCandidates = modelsByYear.get(year) ?? []
+  if (yearCandidates.length === 0) return { code: 'model' as const }
+
+  const playerMatch = uniquePlayerMatches(title, yearCandidates)
+  if (playerMatch.ambiguous) return { code: 'ambiguous-player' as const }
+  if (playerMatch.candidates.length === 0) return { code: 'player' as const }
+
+  let candidates = categoryNarrowedCandidates(title, playerMatch.candidates)
+  const explicitRelease = fanaticsCollectExplicitRelease(item)
+  if (explicitRelease) {
+    const explicitMatches = candidates.filter((candidate) => explicitReleaseMatchesModel(explicitRelease, candidate.model))
+    if (explicitMatches.length > 0) candidates = explicitMatches
+  }
+
+  const modelsByKey = new Map<string, FanaticsWideCandidate>()
+  for (const candidate of candidates) {
+    const key = `${candidate.model.category}:${candidate.model.releaseYear}:${normalizedTitleKey(candidate.model.release)}`
+    modelsByKey.set(key, candidate)
+  }
+  const uniqueCandidates = [...modelsByKey.values()]
+  if (uniqueCandidates.length === 0) return { code: 'model' as const }
+  if (uniqueCandidates.length > 1) return { code: 'ambiguous-model' as const }
+  return { code: 'matched' as const, candidate: uniqueCandidates[0], title, year }
+}
+
+export function mapAuthorizedFanaticsCollectInventory(
+  items: FanaticsCollectHit[],
+  models: ChecklistModel[],
+): { listings: MarketplaceListing[]; stats: FanaticsCollectWideMatchStats } {
+  const stats = emptyWideMatchStats(items.length)
+  const modelsByYear = fanaticsCollectWideCandidates(models)
+  const listings: MarketplaceListing[] = []
+
+  for (const item of items) {
+    const title = firstString([item.title, item.productTitle])
+    if (!fanaticsCollectIsActive(item)) {
+      stats.rejectedInactive += 1
+      continue
+    }
+    if (!fanaticsCollectIsFixedPrice(item)) {
+      stats.rejectedSaleType += 1
+      continue
+    }
+    if (!/\bbowman\b/i.test(title)) {
+      stats.rejectedNonBowman += 1
+      continue
+    }
+    if (!titleLooksLikeAutograph(title)) {
+      stats.rejectedNonAuto += 1
+      continue
+    }
+    if (fanaticsCollectPrice(item) <= 0) {
+      stats.rejectedPrice += 1
+      continue
+    }
+    if (!titleEligibleForBowmanChromeAutoModel(title)) {
+      stats.rejectedTitleGuard += 1
+      continue
+    }
+
+    const resolved = resolveFanaticsCollectWideCandidate(item, modelsByYear)
+    if (resolved.code === 'year') stats.rejectedYear += 1
+    else if (resolved.code === 'player') stats.rejectedPlayer += 1
+    else if (resolved.code === 'ambiguous-player') stats.rejectedAmbiguousPlayer += 1
+    else if (resolved.code === 'model') stats.rejectedModel += 1
+    else if (resolved.code === 'ambiguous-model') stats.rejectedAmbiguousModel += 1
+    if (resolved.code !== 'matched') continue
+
+    const { candidate } = resolved
+    const listing = mapFanaticsCollectHitToListing(
+      {
+        ...item,
+        title,
+        _backstopQuery: {
+          playerName: candidate.playerName,
+          release: candidate.model.release,
+          releaseYear: candidate.model.releaseYear,
+          category: candidate.model.category,
+        },
+      },
+      releaseProductLabel(candidate.model),
+    )
+    if (!listing) {
+      stats.rejectedTitleGuard += 1
+      continue
+    }
+    listings.push(listing)
+  }
+
+  const deduped = dedupeListings(listings)
+  stats.mappedListings = deduped.length
+  return { listings: deduped, stats }
+}
+
+export async function fetchFanaticsCollectStatus(signal?: AbortSignal): Promise<FanaticsCollectStatus> {
+  const response = await fetch('/api/fanatics-collect/status', { signal })
+  const payload = (await response.json()) as FanaticsCollectStatus & { error?: string }
+  if (!response.ok) throw new Error(payload.error ?? 'Could not read Fanatics Collect status')
+  return payload
+}
+
+export async function fetchFanaticsCollectWideListings(options: {
+  models: ChecklistModel[]
+  minPrice?: number
+  pageSize?: number
+  maxPages?: number
+  signal?: AbortSignal
+}): Promise<FanaticsCollectWideScanResult> {
+  if (options.models.length === 0) throw new Error('No checklist models are loaded for the Fanatics wide scan.')
+  const response = await fetch('/api/fanatics-collect/wide-scan', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    signal: options.signal,
+    body: JSON.stringify({
+      minPrice: options.minPrice ?? 0,
+      pageSize: options.pageSize,
+      maxPages: options.maxPages,
+    }),
+  })
+  const payload = (await response.json()) as FanaticsCollectWideSearchResponse
+  if (!response.ok) throw new Error(payload.error ?? 'Fanatics Collect wide scan failed')
+
+  const mapped = mapAuthorizedFanaticsCollectInventory(payload.items ?? [], options.models)
+  const coverage = {
+    complete: Boolean(payload.coverage?.complete),
+    stoppedReason: payload.coverage?.stoppedReason ?? 'unknown',
+    pagesFetched: payload.coverage?.pagesFetched ?? payload.stats?.pagesFetched ?? 0,
+    durationMs: payload.coverage?.durationMs ?? 0,
+  }
+  const errors = [...(payload.errors ?? [])]
+  if (!coverage.complete && errors.length === 0) {
+    errors.push({ error: `Fanatics wide scan is partial (${coverage.stoppedReason}).` })
+  }
+
+  return {
+    listings: mapped.listings,
+    fetchedAt: payload.fetchedAt ?? new Date().toISOString(),
+    errors,
+    stats: {
+      queriesRun: payload.stats?.queriesRun ?? 1,
+      queriesSucceeded: payload.stats?.queriesSucceeded ?? (coverage.complete ? 1 : 0),
+      queriesFailed: payload.stats?.queriesFailed ?? (coverage.complete ? 0 : 1),
+      pagesFetched: payload.stats?.pagesFetched ?? coverage.pagesFetched,
+      upstreamTotal: payload.stats?.upstreamTotal ?? payload.items?.length ?? 0,
+      dedupedItems: payload.stats?.dedupedItems ?? payload.items?.length ?? 0,
+      mappedListings: mapped.listings.length,
+      rejectedPlayerMismatches:
+        mapped.stats.inputItems - mapped.stats.mappedListings,
+      cacheHits: payload.stats?.cacheHits ?? 0,
+      cacheMisses: payload.stats?.cacheMisses ?? 0,
+      cacheWrites: payload.stats?.cacheWrites ?? 0,
+      cacheSkips: payload.stats?.cacheSkips ?? 0,
+      redisCacheHits: payload.stats?.redisCacheHits ?? 0,
+      runtimeCacheHits: payload.stats?.runtimeCacheHits ?? 0,
+      sqliteCacheHits: payload.stats?.sqliteCacheHits ?? 0,
+      upstreamPagesFetched: payload.stats?.upstreamPagesFetched ?? coverage.pagesFetched,
+    },
+    coverage,
+    matchStats: mapped.stats,
+    provenance: {
+      mode: payload.provenance?.mode ?? 'authorized-feed',
+      authorizationId: payload.provenance?.authorizationId ?? null,
+    },
+  }
 }
 
 export async function fetchFanaticsCollectBinListings(options: FetchFanaticsCollectListingsOptions): Promise<EbayBinScanResult> {

--- a/src/lib/fanaticsDealFilters.ts
+++ b/src/lib/fanaticsDealFilters.ts
@@ -1,6 +1,6 @@
 import type { Opportunity } from '../types'
 
-export type FanaticsValueBand = 'fair-or-better' | 'near-model' | 'all'
+export type FanaticsValueBand = 'within-50' | 'fair-or-better' | 'near-model' | 'all'
 export type FanaticsGradeFilter = 'all' | 'raw' | 'graded'
 export type FanaticsDealSort = 'edge' | 'discount' | 'price' | 'confidence'
 
@@ -39,6 +39,7 @@ export function filterFanaticsDealOpportunities(opportunities: Opportunity[], fi
     }
     if (filters.valueBand === 'fair-or-better' && ask > fairValue) return false
     if (filters.valueBand === 'near-model' && ask > fairValue * 1.15) return false
+    if (filters.valueBand === 'within-50' && ask > fairValue * 1.5) return false
     if (filters.grade === 'raw' && opportunity.listing.isGraded) return false
     if (filters.grade === 'graded' && !opportunity.listing.isGraded) return false
     if (filters.maxPrice > 0 && ask > filters.maxPrice) return false

--- a/src/lib/fanaticsDealFilters.ts
+++ b/src/lib/fanaticsDealFilters.ts
@@ -1,0 +1,61 @@
+import type { Opportunity } from '../types'
+
+export type FanaticsValueBand = 'fair-or-better' | 'near-model' | 'all'
+export type FanaticsGradeFilter = 'all' | 'raw' | 'graded'
+export type FanaticsDealSort = 'edge' | 'discount' | 'price' | 'confidence'
+
+export type FanaticsDealFilters = {
+  query: string
+  valueBand: FanaticsValueBand
+  grade: FanaticsGradeFilter
+  sort: FanaticsDealSort
+  maxPrice: number
+  holdsOnly: boolean
+  holdTargets: string[]
+}
+
+export function fanaticsPlayerKey(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+export function filterFanaticsDealOpportunities(opportunities: Opportunity[], filters: FanaticsDealFilters) {
+  const query = fanaticsPlayerKey(filters.query)
+  const holdKeys = new Set(filters.holdTargets.map(fanaticsPlayerKey))
+  const filtered = opportunities.filter((opportunity) => {
+    if (opportunity.listing.marketplace !== 'fanatics-collect') return false
+    const ask = opportunity.listing.allInPrice
+    const fairValue = opportunity.fairValue
+    if (!fairValue || ask <= 0) return false
+    if (query) {
+      const searchText = fanaticsPlayerKey(
+        `${opportunity.listing.playerName} ${opportunity.listing.title} ${opportunity.listing.releaseLabel} ${opportunity.matchedVariation ?? ''}`,
+      )
+      if (!searchText.includes(query) && !query.split(' ').every((word) => searchText.includes(word))) return false
+    }
+    if (filters.valueBand === 'fair-or-better' && ask > fairValue) return false
+    if (filters.valueBand === 'near-model' && ask > fairValue * 1.15) return false
+    if (filters.grade === 'raw' && opportunity.listing.isGraded) return false
+    if (filters.grade === 'graded' && !opportunity.listing.isGraded) return false
+    if (filters.maxPrice > 0 && ask > filters.maxPrice) return false
+    if (filters.holdsOnly && !holdKeys.has(fanaticsPlayerKey(opportunity.listing.playerName))) return false
+    return true
+  })
+
+  return filtered.sort((left, right) => {
+    if (filters.sort === 'discount') {
+      return right.discountPct - left.discountPct || right.edgeDollars - left.edgeDollars
+    }
+    if (filters.sort === 'price') {
+      return left.listing.allInPrice - right.listing.allInPrice || right.edgeDollars - left.edgeDollars
+    }
+    if (filters.sort === 'confidence') {
+      return right.confidence - left.confidence || right.edgeDollars - left.edgeDollars
+    }
+    return right.edgeDollars - left.edgeDollars || right.discountPct - left.discountPct
+  })
+}


### PR DESCRIPTION
## What changed

- adds a permission-gated, cursor-based Fanatics Collect wide-feed adapter
- fails closed unless a written authorization reference and approved feed are configured
- adds strict Bowman prospect-auto matching with year/player/release ambiguity rejection
- namespaces Fanatics listing identities and leaves unknown shipping unknown
- reports complete versus partial scan coverage, page/time budgets, cursor loops, and provenance
- strips images unless downstream image rights are explicitly authorized
- adds a dedicated `/fanatics` prospect-auto page with search, fair/near-model bands, raw/graded and max-price filters, deal sorting, and persistent hold targets
- adds a Fanatics-only wide-scan action to Live Deals
- batches sold-cache enrichment beyond the prior 160-player ceiling
- documents the authorized feed contract and operating guardrails

## Why

Fanatics Collect's current terms prohibit scraping and systematic retrieval, and no public developer API was found. This implements the requested wide-scan and cleaner Collect experience behind an authorized data boundary instead of expanding the undocumented internal search path.

## Validation

- `npm run check`
  - ESLint passed
  - 33 test files / 222 tests passed
  - TypeScript and Vite production build passed
- local browser verification passed for `/deals` and `/fanatics`
  - no console errors
  - no Vite error overlay
  - disabled permission state and dedicated-page layout rendered correctly
