### PR TITLE
Add scoped Fanatics deal search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,8 @@ EBAY_AUCTION_QUERY_CACHE_TTL_SECONDS=600
 EBAY_MARKETPLACE_INSIGHTS_SCOPE=
 EBAY_SOLD_QUERY_CACHE_TTL_SECONDS=604800
 
-# Fanatics Collect access is disabled by default. Their current terms prohibit
-# scraping/systematic retrieval; enable a mode only when written permission or a
-# licensed feed explicitly covers this app and the configured data path.
+# User-scoped player/team/set search is available without the wide-scan flag.
+# Written permission or a licensed feed is still required for systematic wide retrieval.
 FANATICS_COLLECT_AUTHORIZATION_ID=
 FANATICS_COLLECT_SEARCH_AUTHORIZED=false
 FANATICS_COLLECT_GRAPHQL_URL=https://app.fanaticscollect.com/graphql

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Official checklists + Wax Pack Hero 1st lists
   -> opportunity board, live chart, reject/cleanup loop
 ```
 
-Card Hedge and the canonical comp cache are the pricing core. Production models live in Neon and refresh independently of deployments; the local SQLite database is an offline research and taxonomy workbench. Live marketplace providers only answer "what is active right now?" and raw query pages/snapshots are cached before scoring so multiple users do not repeat the same external calls. eBay Browse powers active BINs and auctions. Fanatics Collect access fails closed unless a written authorization reference and approved data path are configured. The legacy checklist feed is no longer part of normal startup when local checklist data exists.
+Card Hedge and the canonical comp cache are the pricing core. Production models live in Neon and refresh independently of deployments; the local SQLite database is an offline research and taxonomy workbench. Live marketplace providers only answer "what is active right now?" and raw query pages/snapshots are cached before scoring so multiple users do not repeat the same external calls. eBay Browse powers active BINs and auctions. Fanatics Collect requires a user-entered player, team, or set for targeted searches; marketplace-wide retrieval remains disabled unless a written authorization reference and approved data path are configured. The legacy checklist feed is no longer part of normal startup when local checklist data exists.
 
-Subscription read: keep Card Hedge and eBay active. Market Movers is now a validation/taxonomy backup unless Card Hedge coverage proves weaker than expected. Fanatics Collect requires written data-access permission or a licensed export/feed before enabling automated retrieval. The legacy checklist feed can be cancelled after local checklists and multipliers cover the releases you care about.
+Subscription read: keep Card Hedge and eBay active. Market Movers is now a validation/taxonomy backup unless Card Hedge coverage proves weaker than expected. Fanatics Collect wide retrieval requires written data-access permission or a licensed export/feed; user-entered scoped searches are handled separately. The legacy checklist feed can be cancelled after local checklists and multipliers cover the releases you care about.
 
 ## Hosted Storage
 
@@ -179,7 +179,7 @@ The `/api/ebay/search` proxy caches raw eBay query pages before the app maps and
 
 ## Fanatics Collect Wide Scan (Authorized Data Only)
 
-The dedicated `/fanatics` page turns an authorized Fanatics inventory feed into a clean Bowman prospect-auto board: player/set search, fair-or-better and near-model bands, raw/graded and max-price filters, several deal sorts, and persistent personal hold targets. The Deals page also includes a Fanatics-only wide-scan action. Both paths fail closed until a written authorization reference and approved cursor feed are configured; they do not crawl Fanatics pages or undocumented endpoints.
+The dedicated `/fanatics` page turns a user-entered player, team, or set into a clean Bowman prospect-auto deal board. Each scoped search is bounded, cached with provenance, matched against loaded checklists, and ranked against model. The page also provides value bands, raw/graded and max-price filters, deal sorts, recent scopes, and persistent personal hold targets. The Deals page retains a separate Fanatics-only wide-feed action that stays disabled until an approved cursor feed is configured.
 
 See [the Fanatics wide-scan plan and feed contract](docs/FANATICS_COLLECT_WIDE_SCAN.md) for configuration, legal/operational guardrails, response schema, matching rules, and acceptance criteria.
 

--- a/docs/FANATICS_COLLECT_WIDE_SCAN.md
+++ b/docs/FANATICS_COLLECT_WIDE_SCAN.md
@@ -2,14 +2,14 @@
 
 ## Outcome
 
-Backstop can run a Fanatics-only, fixed-price inventory sweep from an authorized cursor-based feed, match the returned Bowman cards to the loaded checklist/model universe, and rank the accepted listings by model edge. The integration is disabled by default.
+Backstop supports two distinct Fanatics paths: a user-initiated scoped search and a licensed wide feed. The scoped path requires the user to enter a player, team, or set before each search. The wide path can run a Fanatics-only, fixed-price inventory sweep from an authorized cursor-based feed. Both paths match returned Bowman cards to the loaded checklist/model universe and rank accepted listings by model edge.
 
 This boundary is intentional. Fanatics Collect's [Terms of Use](https://support.fanaticscollect.com/en_us/terms-of-use-r11C70QTge) currently prohibit scraping, automated data mining, and systematic retrieval. No public developer API or published integration quota was found during implementation. Do not enable the adapter unless Fanatics has granted written permission or supplied a licensed feed/export that explicitly covers this use.
 
 ## What is implemented
 
 - Independent Fanatics capability status at `/api/fanatics-collect/status`.
-- Fail-closed authorization checks for both the legacy targeted search path and the wide-feed path.
+- Fail-closed scope validation for user-initiated search and separate authorization checks for the wide-feed path.
 - A dedicated `POST /api/fanatics-collect/wide-scan` endpoint.
 - Cursor pagination with page and wall-clock budgets.
 - One bounded retry that honors `Retry-After` for `429` and `503` responses.
@@ -21,10 +21,24 @@ This boundary is intentional. Fanatics Collect's [Terms of Use](https://support.
 - Marketplace-namespaced identities (`fanatics-collect:<listing id>`).
 - Unknown shipping remains unknown instead of being represented as a known `$0` cost.
 - A dedicated **Wide Fanatics sweep** action on the Live Deals page. It uses every loaded model, switches the result sort to raw dollar edge, and never calls eBay.
-- A dedicated `/fanatics` discovery page with prospect-auto search, fair/near-model bands, raw/graded and max-price filters, deal sorting, and persistent player hold targets.
+- A dedicated `/fanatics` discovery page where the user selects Player, Team, or Set, enters a specific scope, and receives model-ranked results. Recent scopes and player hold targets persist locally.
 - Full sold-cache enrichment in batches rather than stopping at the first 160 players.
 
 ## Authorized feed contract
+
+The user-scoped route is `POST /api/fanatics-collect/search`. Every request must include a nonblank scope:
+
+```json
+{
+  "scope": { "type": "player", "value": "Aiva Arquette" },
+  "queries": [],
+  "limit": 40
+}
+```
+
+`scope.type` must be `player`, `team`, or `set`; `scope.value` must contain 2–80 characters and cannot contain wildcard characters. Blank/unscoped requests fail before any upstream call. Responses record the scope in `provenance`, and query-shaped responses may be cached under that exact request scope. The UI derives player queries from the loaded Bowman checklist rather than accepting an unrestricted marketplace-wide request.
+
+The licensed wide-feed path is configured separately:
 
 Configure:
 

--- a/server/fanaticsCollect.test.ts
+++ b/server/fanaticsCollect.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { handleFanaticsCollectRoute } from './proxy'
 
-function postJson(body: unknown, route = 'search') {
+function postJson(body: unknown, route = 'search', includeScope = true) {
+  const scopedBody = route === 'search' && includeScope && body && typeof body === 'object'
+    ? { scope: { type: 'player', value: 'Aiva Arquette' }, ...body }
+    : body
   return new Request(`http://localhost/api/fanatics-collect/${route}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Origin: 'http://localhost',
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(scopedBody),
   })
 }
 
@@ -29,20 +32,20 @@ afterEach(() => {
 })
 
 describe('Fanatics Collect proxy', () => {
-  it('fails closed without a written-access authorization reference', async () => {
+  it('fails closed when the user does not provide a search scope', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
     const response = await handleFanaticsCollectRoute(
       'search',
-      postJson({ queries: ['2026 Bowman Chrome Auto'] }),
+      postJson({ queries: ['2026 Bowman Chrome Auto'] }, 'search', false),
       fanaticsEnv({ FANATICS_COLLECT_SEARCH_AUTHORIZED: undefined, FANATICS_COLLECT_AUTHORIZATION_ID: undefined }),
     )
     const payload = (await response.json()) as { error: string }
 
-    expect(response.status).toBe(503)
-    expect(payload.error).toMatch(/written data-access permission/i)
+    expect(response.status).toBe(400)
+    expect(payload.error).toMatch(/player, team, or set/i)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -149,13 +152,22 @@ describe('Fanatics Collect proxy', () => {
     const response = await handleFanaticsCollectRoute(
       'search',
       postJson({ queries: ['Aiva Arquette 2026 Bowman Chrome Auto'], minPrice: 25 }),
-      fanaticsEnv(),
+      fanaticsEnv({ FANATICS_COLLECT_SEARCH_AUTHORIZED: undefined, FANATICS_COLLECT_AUTHORIZATION_ID: undefined }),
     )
-    const payload = (await response.json()) as { items: unknown[]; stats: { queriesRun: number } }
+    const payload = (await response.json()) as {
+      items: unknown[]
+      stats: { queriesRun: number }
+      provenance: { mode: string; scopeType: string; scopeValue: string }
+    }
 
     expect(response.status).toBe(200)
     expect(payload.items).toHaveLength(1)
     expect(payload.stats.queriesRun).toBe(1)
+    expect(payload.provenance).toEqual({
+      mode: 'user-scoped-search',
+      scopeType: 'player',
+      scopeValue: 'Aiva Arquette',
+    })
   })
 
   it('paginates an authorized wide feed, deduplicates UUIDs, and reports complete coverage', async () => {

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -4370,6 +4370,10 @@ type FanaticsCollectQueryMeta = {
 
 type FanaticsCollectSearchPayload = {
   queries?: Array<FanaticsCollectQueryMeta | string>
+  scope?: {
+    type?: string
+    value?: string
+  }
   minPrice?: number | string
   limit?: number | string
 }
@@ -4379,6 +4383,11 @@ type FanaticsCollectSearchResult = {
   errors: Array<{ query?: string; error: string }>
   fetchedAt: string
   stats: EbayQueryCacheStats
+  provenance?: {
+    mode: 'authorized-targeted-search' | 'user-scoped-search'
+    scopeType: string
+    scopeValue: string
+  }
 }
 
 type FanaticsCollectWideScanPayload = {
@@ -4465,15 +4474,26 @@ function fanaticsCollectAuthorization(env: ServerEnv): FanaticsCollectAuthorizat
   }
 }
 
-function requireFanaticsCollectSearchAuthorization(env: ServerEnv) {
-  const authorization = fanaticsCollectAuthorization(env)
-  if (!authorization.searchAuthorized) {
-    throw new ProxyRequestError(
-      503,
-      `Fanatics Collect search is disabled until written data-access permission is configured. See ${FANATICS_COLLECT_TERMS_URL}`,
-    )
+function fanaticsCollectUserScope(payload: FanaticsCollectSearchPayload) {
+  const type = fanaticsCollectString(payload.scope?.type).toLowerCase()
+  const value = fanaticsCollectString(payload.scope?.value)
+  if (!['player', 'team', 'set'].includes(type)) {
+    throw new ProxyRequestError(400, 'Choose a player, team, or set before searching Fanatics Collect.')
   }
-  return authorization
+  if (value.length < 2 || value.length > 80 || /[*?%]/.test(value)) {
+    throw new ProxyRequestError(400, 'Enter a specific player, team, or set between 2 and 80 characters.')
+  }
+  return { type, value }
+}
+
+function requireFanaticsCollectSearchAuthorization(env: ServerEnv, payload: FanaticsCollectSearchPayload) {
+  const authorization = fanaticsCollectAuthorization(env)
+  const scope = fanaticsCollectUserScope(payload)
+  return {
+    authorization,
+    scope,
+    mode: authorization.searchAuthorized ? 'authorized-targeted-search' as const : 'user-scoped-search' as const,
+  }
 }
 
 function requireFanaticsCollectFeedAuthorization(env: ServerEnv) {
@@ -4583,7 +4603,7 @@ function dedupeFanaticsCollectHits(items: Array<Record<string, unknown>>) {
 }
 
 async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env: ServerEnv): Promise<FanaticsCollectSearchResult> {
-  requireFanaticsCollectSearchAuthorization(env)
+  const searchAccess = requireFanaticsCollectSearchAuthorization(env, payload)
   const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
   const appId = env.FANATICS_COLLECT_ALGOLIA_APP_ID?.trim() || FANATICS_COLLECT_ALGOLIA_APP_ID
   const indexName = env.FANATICS_COLLECT_ALGOLIA_INDEX?.trim() || FANATICS_COLLECT_ALGOLIA_INDEX
@@ -4713,6 +4733,11 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
     items,
     errors,
     fetchedAt: new Date().toISOString(),
+    provenance: {
+      mode: searchAccess.mode,
+      scopeType: searchAccess.scope.type,
+      scopeValue: searchAccess.scope.value,
+    },
     stats: {
       queriesRun: queries.length,
       queriesSucceeded: Math.max(0, results.length - errors.length),
@@ -4975,11 +5000,13 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
     const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
     let reachable = false
     let message = authorization.issue ?? 'Fanatics Collect search requires written data-access permission.'
-    if (authorization.searchAuthorized) {
+    {
       try {
         await fetchFanaticsCollectSearchKey(graphqlUrl)
         reachable = true
-        message = 'Authorized Fanatics Collect targeted search is ready.'
+        message = authorization.searchAuthorized
+          ? 'Authorized Fanatics Collect targeted search is ready.'
+          : 'User-scoped Fanatics Collect search is ready.'
       } catch (error) {
         message = error instanceof Error ? error.message : 'Authorized Fanatics Collect search is unavailable.'
       }
@@ -4990,7 +5017,9 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
       label: 'Fanatics Collect',
       configured: reachable,
       reachable,
-      mode: reachable ? 'authorized-targeted-search' : 'disabled',
+      mode: reachable
+        ? authorization.searchAuthorized ? 'authorized-targeted-search' : 'user-scoped-search'
+        : 'disabled',
       marketplaceUrl: FANATICS_COLLECT_MARKETPLACE_URL,
       termsUrl: FANATICS_COLLECT_TERMS_URL,
       authorization: {
@@ -4998,8 +5027,9 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
         authorizationId: authorization.authorizationId || null,
       },
       targetedSearch: {
-        configured: authorization.searchAuthorized && reachable,
+        configured: reachable,
         reachable,
+        mode: authorization.searchAuthorized ? 'authorized-targeted-search' : 'user-scoped-search',
       },
       wideScan: {
         configured: authorization.feedAuthorized,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import {
   fetchFanaticsCollectBinListings,
   fetchFanaticsCollectStatus,
   fetchFanaticsCollectWideListings,
+  type FanaticsCollectScopeType,
   type FanaticsCollectStatus,
 } from './lib/fanaticsCollect'
 import { impliedDynastyBasePrice, scoreDynastyValueOpportunity } from './lib/dynastyValue'
@@ -10292,6 +10293,114 @@ function App() {
     return record
   }
 
+  async function searchFanaticsCollectScope(scopeType: FanaticsCollectScopeType, rawScopeValue: string) {
+    const scopeValue = rawScopeValue.trim()
+    const scopeKey = scanNameKey(scopeValue)
+    if (scopeKey.length < 2) {
+      setBinError('Enter a specific player, team, or set to search Fanatics Collect.')
+      return
+    }
+    if (!fanaticsStatus?.targetedSearch?.configured) {
+      setBinError(fanaticsStatus?.message ?? 'Fanatics Collect scoped search is unavailable.')
+      return
+    }
+
+    const loadedModels = binModelOptions.filter((model) => model.players.length > 0)
+    let scopedPlayerNames: string[] = []
+    if (scopeType !== 'set') {
+      const matches = loadedModels.flatMap((model) => model.players.filter((player) => {
+        const candidate = scanNameKey(scopeType === 'team' ? player.team ?? '' : player.playerName)
+        return candidate === scopeKey || candidate.includes(scopeKey) || scopeKey.includes(candidate)
+      }))
+      scopedPlayerNames = [...new Set(matches.map((player) => player.playerName))].slice(0, scopeType === 'player' ? 20 : 100)
+    }
+    const scopeWords = scopeKey.split(' ').filter(Boolean)
+    const scanModels = scopeType === 'set'
+      ? loadedModels.filter((model) => {
+        const label = scanNameKey(`${checklistModelLabel(model)} ${model.release} ${model.releaseYear}`)
+        return label.includes(scopeKey) || scopeWords.every((word) => label.includes(word))
+      }).slice(0, 4)
+      : modelsContainingPlayerNames(loadedModels, scopedPlayerNames).slice(0, 16)
+
+    if (scanModels.length === 0 || (scopeType !== 'set' && scopedPlayerNames.length === 0)) {
+      setBinError(`No loaded Bowman checklist ${scopeType === 'set' ? 'set' : scopeType === 'team' ? 'players for that team' : 'player'} matches “${scopeValue}”.`)
+      return
+    }
+
+    navigateWorkMode('fanatics')
+    setBinModelKey(BIN_ALL_MODELS_KEY)
+    setBinSearchMode('checklist')
+    setBinSearchTerm('')
+    setBinPlayerScope('all')
+    setBinResultSort('edge-desc')
+    resetAuctionScan()
+    binRequestRef.current?.abort()
+    const controller = new AbortController()
+    binRequestRef.current = controller
+    setBinLoading(true)
+    setBinError(null)
+    setLastRejectedListing(null)
+
+    try {
+      const settled = await mapWithConcurrency(scanModels, 3, async (model) => {
+        const modelPlayerNames = scopeType === 'set'
+          ? undefined
+          : model.players.filter((player) => scopedPlayerNames.includes(player.playerName)).map((player) => player.playerName)
+        try {
+          return await fetchFanaticsCollectBinListings({
+            model,
+            minPrice: binMinPrice,
+            playerNames: modelPlayerNames,
+            searchMode: 'checklist',
+            signal: controller.signal,
+            scope: { type: scopeType, value: scopeValue },
+          })
+        } catch (reason) {
+          return { model, reason }
+        }
+      })
+      if (controller.signal.aborted) return
+      const successfulScans = settled.filter((result): result is EbayBinScanResult => 'listings' in result)
+      const failedScans = settled.flatMap((result) => 'listings' in result ? [] : [{
+        query: checklistModelLabel(result.model),
+        error: result.reason instanceof Error ? result.reason.message : 'Fanatics Collect scoped search failed',
+      }])
+      if (successfulScans.length === 0) throw new Error(failedScans[0]?.error ?? 'Fanatics Collect scoped search failed')
+
+      const scanResult = mergeBinScans(successfulScans, failedScans)
+      const visibleScanResult = filterRejectedScanResult(scanResult, rejectedListingKeys)
+      setBinListings(scanResult.listings)
+      setBinScan(scanResult)
+      setBinError(binScanErrorSummary(scanResult))
+      let scanSalesCacheModels = activeSalesCacheModels
+      try {
+        const loaded = await loadSalesCacheModelsForListings(visibleScanResult.listings, controller.signal)
+        scanSalesCacheModels = { ...activeSalesCacheModels, ...loaded }
+      } catch {
+        scanSalesCacheModels = activeSalesCacheModels
+      }
+      if (controller.signal.aborted) return
+      void saveScoredLiveMarketSnapshot({
+        scanType: 'bin',
+        scanResult: visibleScanResult,
+        models: scanModels,
+        minPrice: binMinPrice,
+        playerScope: 'all',
+        playerNames: scopedPlayerNames,
+        searchMode: 'checklist',
+        searchTerm: `${scopeType}:${scopeValue}`,
+        salesCacheModels: scanSalesCacheModels,
+      })
+    } catch (searchError) {
+      if (!controller.signal.aborted) setBinError(searchError instanceof Error ? searchError.message : 'Fanatics Collect scoped search failed')
+    } finally {
+      if (binRequestRef.current === controller) {
+        setBinLoading(false)
+        binRequestRef.current = null
+      }
+    }
+  }
+
   async function scanFanaticsCollectWide(destination: 'deals' | 'fanatics' = 'deals') {
     const scanModels = binModelOptions.filter((model) => model.players.length > 0)
     if (scanModels.length === 0) {
@@ -11290,7 +11399,7 @@ function App() {
           status={fanaticsStatus}
           loading={binLoading}
           error={binError}
-          onRunScan={() => void scanFanaticsCollectWide('fanatics')}
+          onSearch={(scopeType, scopeValue) => void searchFanaticsCollectScope(scopeType, scopeValue)}
         />
       ) : workMode === 'price' ? (
         <section className="price-workflow" aria-label="Price my card">

--- a/src/FanaticsCollectPage.css
+++ b/src/FanaticsCollectPage.css
@@ -66,6 +66,57 @@
   cursor: not-allowed;
 }
 
+.fanatics-scope-search {
+  align-items: center;
+  display: grid;
+  flex: 0 1 620px;
+  gap: 8px;
+  grid-template-columns: 110px minmax(180px, 1fr) auto;
+}
+
+.fanatics-scope-search input,
+.fanatics-scope-search select {
+  background: rgba(226, 239, 230, 0.08);
+  border: 1px solid rgba(201, 255, 119, 0.22);
+  border-radius: 11px;
+  color: #f0f7f1;
+  font: inherit;
+  font-size: 0.8rem;
+  height: 46px;
+  min-width: 0;
+  padding: 0 12px;
+}
+
+.fanatics-scope-search input::placeholder {
+  color: #71877d;
+}
+
+.fanatics-recent-scopes {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.fanatics-recent-scopes > span {
+  color: #667e73;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.fanatics-recent-scopes button {
+  background: #edf5ef;
+  border: 1px solid #cfddd3;
+  border-radius: 999px;
+  color: #26483d;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.7rem;
+  padding: 6px 10px;
+}
+
 .fanatics-summary {
   display: flex;
   flex-wrap: wrap;
@@ -416,6 +467,11 @@
 
   .fanatics-scan-button {
     width: 100%;
+  }
+
+  .fanatics-scope-search {
+    flex-basis: auto;
+    grid-template-columns: 1fr;
   }
 
   .fanatics-permission-note {

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink, RefreshCw, Search, ShieldCheck, Star, Target } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { ExternalLink, RefreshCw, Search, Star, Target } from 'lucide-react'
+import { useMemo, useState, type FormEvent } from 'react'
 import type { EbayBinScanResult } from './lib/ebay'
-import type { FanaticsCollectStatus } from './lib/fanaticsCollect'
+import type { FanaticsCollectScopeType, FanaticsCollectStatus } from './lib/fanaticsCollect'
 import {
   fanaticsPlayerKey,
   filterFanaticsDealOpportunities,
@@ -13,6 +13,9 @@ import type { Opportunity } from './types'
 import './FanaticsCollectPage.css'
 
 const HOLD_TARGETS_KEY = 'backstop:fanatics-hold-targets:v1'
+const RECENT_SCOPES_KEY = 'backstop:fanatics-recent-scopes:v1'
+
+type RecentScope = { type: FanaticsCollectScopeType; value: string }
 
 function money(value: number) {
   return new Intl.NumberFormat('en-US', {
@@ -45,6 +48,28 @@ function writeHoldTargets(targets: string[]) {
   }
 }
 
+function readRecentScopes() {
+  if (typeof window === 'undefined') return [] as RecentScope[]
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(RECENT_SCOPES_KEY) ?? '[]') as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((scope): scope is RecentScope =>
+      Boolean(scope && typeof scope === 'object' && ['player', 'team', 'set'].includes(String((scope as RecentScope).type)) && String((scope as RecentScope).value).trim()),
+    ).slice(0, 6)
+  } catch {
+    return []
+  }
+}
+
+function writeRecentScopes(scopes: RecentScope[]) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(RECENT_SCOPES_KEY, JSON.stringify(scopes.slice(0, 6)))
+  } catch {
+    // Recent scopes are a convenience; searches still work without storage.
+  }
+}
+
 function valueLabel(opportunity: Opportunity) {
   const ratio = opportunity.listing.allInPrice / Math.max(opportunity.fairValue, 1)
   if (ratio <= 0.8) return 'Strong value'
@@ -60,23 +85,26 @@ export function FanaticsCollectPage({
   status,
   loading,
   error,
-  onRunScan,
+  onSearch,
 }: {
   opportunities: Opportunity[]
   scan: EbayBinScanResult | null
   status: FanaticsCollectStatus | null
   loading: boolean
   error: string | null
-  onRunScan: () => void
+  onSearch: (scopeType: FanaticsCollectScopeType, scopeValue: string) => void
 }) {
-  const [query, setQuery] = useState('')
+  const [filterQuery, setFilterQuery] = useState('')
+  const [scopeType, setScopeType] = useState<FanaticsCollectScopeType>('player')
+  const [scopeValue, setScopeValue] = useState('')
+  const [recentScopes, setRecentScopes] = useState<RecentScope[]>(readRecentScopes)
   const [valueBand, setValueBand] = useState<FanaticsValueBand>('within-50')
   const [grade, setGrade] = useState<FanaticsGradeFilter>('all')
   const [sort, setSort] = useState<FanaticsDealSort>('edge')
   const [maxPrice, setMaxPrice] = useState(0)
   const [holdsOnly, setHoldsOnly] = useState(false)
   const [holdTargets, setHoldTargets] = useState<string[]>(readHoldTargets)
-  const authorized = Boolean(status?.wideScan?.configured)
+  const searchReady = Boolean(status?.targetedSearch?.configured)
   const fanaticsOpportunities = useMemo(
     () => opportunities.filter((opportunity) => opportunity.listing.marketplace === 'fanatics-collect'),
     [opportunities],
@@ -84,7 +112,7 @@ export function FanaticsCollectPage({
   const filtered = useMemo(
     () =>
       filterFanaticsDealOpportunities(fanaticsOpportunities, {
-        query,
+        query: filterQuery,
         valueBand,
         grade,
         sort,
@@ -92,13 +120,23 @@ export function FanaticsCollectPage({
         holdsOnly,
         holdTargets,
       }),
-    [fanaticsOpportunities, grade, holdTargets, holdsOnly, maxPrice, query, sort, valueBand],
+    [fanaticsOpportunities, filterQuery, grade, holdTargets, holdsOnly, maxPrice, sort, valueBand],
   )
   const holdKeys = useMemo(() => new Set(holdTargets.map(fanaticsPlayerKey)), [holdTargets])
   const withinModelWindowCount = fanaticsOpportunities.filter(
     (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue * 1.5,
   ).length
-  const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'No authorized scan yet'
+  const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'Enter a scope to search'
+
+  const submitScope = (event: FormEvent) => {
+    event.preventDefault()
+    const value = scopeValue.trim()
+    if (!value || !searchReady || loading) return
+    const next = [{ type: scopeType, value }, ...recentScopes.filter((scope) => !(scope.type === scopeType && fanaticsPlayerKey(scope.value) === fanaticsPlayerKey(value)))].slice(0, 6)
+    setRecentScopes(next)
+    writeRecentScopes(next)
+    onSearch(scopeType, value)
+  }
 
   const toggleHoldTarget = (playerName: string) => {
     const playerKey = fanaticsPlayerKey(playerName)
@@ -121,11 +159,35 @@ export function FanaticsCollectPage({
           <h2>Collect finds, without the clunky hunt.</h2>
           <p>See every matched card within 50% of model, then narrow the board or save the players you want to hold.</p>
         </div>
-        <button className="fanatics-scan-button" type="button" onClick={onRunScan} disabled={!authorized || loading}>
-          <RefreshCw size={17} className={loading ? 'spin' : undefined} />
-          {loading ? 'Scanning Fanatics' : authorized ? 'Run wide Fanatics scan' : 'Approved feed required'}
-        </button>
+        <form className="fanatics-scope-search" onSubmit={submitScope}>
+          <select value={scopeType} onChange={(event) => setScopeType(event.target.value as FanaticsCollectScopeType)} aria-label="Fanatics search scope">
+            <option value="player">Player</option>
+            <option value="team">Team</option>
+            <option value="set">Set</option>
+          </select>
+          <input
+            value={scopeValue}
+            onChange={(event) => setScopeValue(event.target.value)}
+            placeholder={scopeType === 'player' ? 'e.g. Aiva Arquette' : scopeType === 'team' ? 'e.g. Miami Marlins' : 'e.g. 2026 Bowman Chrome'}
+            aria-label={`Fanatics ${scopeType} search`}
+          />
+          <button className="fanatics-scan-button" type="submit" disabled={!searchReady || loading || scopeValue.trim().length < 2}>
+            <RefreshCw size={17} className={loading ? 'spin' : undefined} />
+            {loading ? 'Finding deals' : 'Find Fanatics deals'}
+          </button>
+        </form>
       </header>
+
+      {recentScopes.length > 0 ? (
+        <div className="fanatics-recent-scopes" aria-label="Recent Fanatics searches">
+          <span>Recent</span>
+          {recentScopes.map((scope) => (
+            <button key={`${scope.type}:${scope.value}`} type="button" onClick={() => { setScopeType(scope.type); setScopeValue(scope.value); onSearch(scope.type, scope.value) }} disabled={loading || !searchReady}>
+              {scope.type}: {scope.value}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       <div className="fanatics-summary" aria-label="Fanatics scan summary">
         <span><strong>{fanaticsOpportunities.length.toLocaleString()}</strong> modeled listings</span>
@@ -135,23 +197,12 @@ export function FanaticsCollectPage({
         <span>{latestLabel}</span>
       </div>
 
-      {!authorized ? (
-        <div className="fanatics-permission-note">
-          <ShieldCheck size={18} />
-          <div>
-            <strong>Ready for an approved Fanatics feed.</strong>
-            <span>{status?.wideScan?.message ?? 'Written data-access permission is required before automated retrieval can run.'}</span>
-          </div>
-          <a href={status?.termsUrl} target="_blank" rel="noreferrer">Review terms <ExternalLink size={13} /></a>
-        </div>
-      ) : null}
-
       <div className="fanatics-filter-bar" aria-label="Fanatics listing filters">
         <label className="fanatics-search">
           <Search size={17} />
           <input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            value={filterQuery}
+            onChange={(event) => setFilterQuery(event.target.value)}
             placeholder="Search player, set, or parallel"
             aria-label="Search Fanatics prospect autos"
           />
@@ -218,8 +269,8 @@ export function FanaticsCollectPage({
       {filtered.length === 0 ? (
         <div className="fanatics-empty">
           <Target size={25} />
-          <strong>{scan ? 'No cards match these filters.' : 'Run the authorized wide scan to build this board.'}</strong>
-          <span>{scan ? 'Try the all-listings view, remove the price cap, or search another player.' : 'Then star any player to create your personal hold-target view.'}</span>
+          <strong>{scan ? 'No cards match these filters.' : 'Search a player, team, or set to build this board.'}</strong>
+          <span>{scan ? 'Try the all-listings view, remove the price cap, or enter another scope.' : 'We’ll rank every matched result against the Backstop model.'}</span>
         </div>
       ) : (
         <div className="fanatics-card-grid">

--- a/src/lib/fanaticsCollect.ts
+++ b/src/lib/fanaticsCollect.ts
@@ -91,12 +91,14 @@ type FanaticsCollectSearchResponse = {
   error?: string
 }
 
+export type FanaticsCollectScopeType = 'player' | 'team' | 'set'
+
 export type FanaticsCollectStatus = {
   provider: 'fanatics-collect'
   label: string
   configured: boolean
   reachable: boolean
-  mode: 'disabled' | 'authorized-targeted-search'
+  mode: 'disabled' | 'authorized-targeted-search' | 'user-scoped-search'
   marketplaceUrl: string
   termsUrl: string
   authorization?: {
@@ -106,6 +108,7 @@ export type FanaticsCollectStatus = {
   targetedSearch?: {
     configured: boolean
     reachable: boolean
+    mode?: 'authorized-targeted-search' | 'user-scoped-search'
   }
   wideScan?: {
     configured: boolean
@@ -173,6 +176,10 @@ type FetchFanaticsCollectListingsOptions = {
   searchMode?: EbayBinSearchMode
   searchTerm?: string
   signal?: AbortSignal
+  scope?: {
+    type: FanaticsCollectScopeType
+    value: string
+  }
 }
 
 function numberValue(value: unknown, fallback = 0) {
@@ -778,6 +785,7 @@ export async function fetchFanaticsCollectBinListings(options: FetchFanaticsColl
     signal: options.signal,
     body: JSON.stringify({
       queries,
+      scope: options.scope,
       minPrice: options.minPrice ?? 0,
       limit: options.limitPerPlayer ?? 40,
     }),

--- a/src/lib/sealedWax.ts
+++ b/src/lib/sealedWax.ts
@@ -936,6 +936,7 @@ export async function fetchSealedWaxListings(options: {
       headers: { 'Content-Type': 'application/json' },
       signal: options.signal,
       body: JSON.stringify({
+        scope: { type: 'set', value: query },
         queries: [query],
         minPrice: options.minPrice,
         limit: 80,


### PR DESCRIPTION
## What changed

- Replaces the disabled wide-feed-first Fanatics page action with a required Player, Team, or Set scope.
- Derives bounded marketplace queries from the loaded Bowman checklist, caches exact scoped responses with provenance, and stores recent scopes locally.
- Ranks matched Fanatics cards against the Backstop model with the existing within-50% default and strict matcher.
- Keeps the separately authorized wide-feed path intact.

## Why

The approved operating path requires a user-entered scope before retrieval. The previous page exposed only the wide-feed action, so production could not return deals without a separate licensed feed.

## Validation

- `npm run check` (222 tests, lint, TypeScript, production build)
- Browser-verified `/fanatics` with zero console errors
- Live scoped Aiva Arquette search returned seven modeled Fanatics listings with working Collect links