### PR TITLE
Add Fanatics scope autocomplete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import './BackstopV2.css'
 import { FanaticsCollectPage } from './FanaticsCollectPage'
+import { buildFanaticsScopeOptions, fanaticsScopedPlayerNames } from './lib/fanaticsScopeOptions'
 import {
   fetchChecklistCatalog,
   fetchChecklistModel,
@@ -9169,6 +9170,13 @@ function App() {
     [checklistModels],
   )
   const binModelOptions = useMemo(() => sortChecklistModels(checklistModels), [checklistModels])
+  const fanaticsScopeOptions = useMemo(
+    () => buildFanaticsScopeOptions(
+      binModelOptions,
+      (playerName, checklistTeam) => teamDisplayName(checklistTeam ?? findStsRanking(playerName)?.team),
+    ),
+    [binModelOptions],
+  )
   const marlinsChecklistPlayerNamesByModel = useMemo(() => {
     void rankingsDatasetVersion
     const byModel = new Map<string, string[]>()
@@ -10308,11 +10316,13 @@ function App() {
     const loadedModels = binModelOptions.filter((model) => model.players.length > 0)
     let scopedPlayerNames: string[] = []
     if (scopeType !== 'set') {
-      const matches = loadedModels.flatMap((model) => model.players.filter((player) => {
-        const candidate = scanNameKey(scopeType === 'team' ? player.team ?? '' : player.playerName)
-        return candidate === scopeKey || candidate.includes(scopeKey) || scopeKey.includes(candidate)
-      }))
-      scopedPlayerNames = [...new Set(matches.map((player) => player.playerName))].slice(0, scopeType === 'player' ? 20 : 100)
+      const resolvedScopeValue = scopeType === 'team' ? teamDisplayName(scopeValue) : scopeValue
+      scopedPlayerNames = fanaticsScopedPlayerNames(
+        loadedModels,
+        scopeType,
+        resolvedScopeValue,
+        (playerName, checklistTeam) => teamDisplayName(checklistTeam ?? findStsRanking(playerName)?.team),
+      ).slice(0, scopeType === 'player' ? 20 : 100)
     }
     const scopeWords = scopeKey.split(' ').filter(Boolean)
     const scanModels = scopeType === 'set'
@@ -11399,6 +11409,7 @@ function App() {
           status={fanaticsStatus}
           loading={binLoading}
           error={binError}
+          scopeOptions={fanaticsScopeOptions}
           onSearch={(scopeType, scopeValue) => void searchFanaticsCollectScope(scopeType, scopeValue)}
         />
       ) : workMode === 'price' ? (

--- a/src/FanaticsCollectPage.css
+++ b/src/FanaticsCollectPage.css
@@ -74,6 +74,12 @@
   grid-template-columns: 110px minmax(180px, 1fr) auto;
 }
 
+.fanatics-scope-panel {
+  display: grid;
+  flex: 0 1 620px;
+  gap: 6px;
+}
+
 .fanatics-scope-search input,
 .fanatics-scope-search select {
   background: rgba(226, 239, 230, 0.08);
@@ -89,6 +95,12 @@
 
 .fanatics-scope-search input::placeholder {
   color: #71877d;
+}
+
+.fanatics-scope-count {
+  color: #81968c;
+  font-size: 0.66rem;
+  padding-left: 118px;
 }
 
 .fanatics-recent-scopes {
@@ -472,6 +484,10 @@
   .fanatics-scope-search {
     flex-basis: auto;
     grid-template-columns: 1fr;
+  }
+
+  .fanatics-scope-count {
+    padding-left: 0;
   }
 
   .fanatics-permission-note {

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -2,6 +2,7 @@ import { ExternalLink, RefreshCw, Search, Star, Target } from 'lucide-react'
 import { useMemo, useState, type FormEvent } from 'react'
 import type { EbayBinScanResult } from './lib/ebay'
 import type { FanaticsCollectScopeType, FanaticsCollectStatus } from './lib/fanaticsCollect'
+import type { FanaticsScopeOptions } from './lib/fanaticsScopeOptions'
 import {
   fanaticsPlayerKey,
   filterFanaticsDealOpportunities,
@@ -85,6 +86,7 @@ export function FanaticsCollectPage({
   status,
   loading,
   error,
+  scopeOptions,
   onSearch,
 }: {
   opportunities: Opportunity[]
@@ -92,6 +94,7 @@ export function FanaticsCollectPage({
   status: FanaticsCollectStatus | null
   loading: boolean
   error: string | null
+  scopeOptions: FanaticsScopeOptions
   onSearch: (scopeType: FanaticsCollectScopeType, scopeValue: string) => void
 }) {
   const [filterQuery, setFilterQuery] = useState('')
@@ -127,6 +130,12 @@ export function FanaticsCollectPage({
     (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue * 1.5,
   ).length
   const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'Enter a scope to search'
+  const activeScopeOptions = scopeOptions[scopeType]
+  const scopeListId = `fanatics-${scopeType}-options`
+  const scopeOptionNodes = useMemo(
+    () => activeScopeOptions.map((option) => <option value={option} key={option} />),
+    [activeScopeOptions],
+  )
 
   const submitScope = (event: FormEvent) => {
     event.preventDefault()
@@ -159,8 +168,16 @@ export function FanaticsCollectPage({
           <h2>Collect finds, without the clunky hunt.</h2>
           <p>See every matched card within 50% of model, then narrow the board or save the players you want to hold.</p>
         </div>
+        <div className="fanatics-scope-panel">
         <form className="fanatics-scope-search" onSubmit={submitScope}>
-          <select value={scopeType} onChange={(event) => setScopeType(event.target.value as FanaticsCollectScopeType)} aria-label="Fanatics search scope">
+          <select
+            value={scopeType}
+            onChange={(event) => {
+              setScopeType(event.target.value as FanaticsCollectScopeType)
+              setScopeValue('')
+            }}
+            aria-label="Fanatics search scope"
+          >
             <option value="player">Player</option>
             <option value="team">Team</option>
             <option value="set">Set</option>
@@ -168,14 +185,22 @@ export function FanaticsCollectPage({
           <input
             value={scopeValue}
             onChange={(event) => setScopeValue(event.target.value)}
+            list={scopeListId}
             placeholder={scopeType === 'player' ? 'e.g. Aiva Arquette' : scopeType === 'team' ? 'e.g. Miami Marlins' : 'e.g. 2026 Bowman Chrome'}
             aria-label={`Fanatics ${scopeType} search`}
           />
+          <datalist id={scopeListId}>
+            {scopeOptionNodes}
+          </datalist>
           <button className="fanatics-scan-button" type="submit" disabled={!searchReady || loading || scopeValue.trim().length < 2}>
             <RefreshCw size={17} className={loading ? 'spin' : undefined} />
             {loading ? 'Finding deals' : 'Find Fanatics deals'}
           </button>
         </form>
+        <small className="fanatics-scope-count">
+          {activeScopeOptions.length.toLocaleString()} {scopeType === 'set' ? 'sets' : `${scopeType}s`} available
+        </small>
+        </div>
       </header>
 
       {recentScopes.length > 0 ? (

--- a/src/lib/fanaticsScopeOptions.test.ts
+++ b/src/lib/fanaticsScopeOptions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { ChecklistModel } from '../types'
+import { buildFanaticsScopeOptions, fanaticsScopedPlayerNames } from './fanaticsScopeOptions'
+
+function model(release: string, players: Array<{ playerName: string; team?: string | null }>): ChecklistModel {
+  return {
+    category: 'chrome',
+    source: 'public-multipliers',
+    release,
+    releaseYear: 2026,
+    fetchedAt: '2026-07-11T00:00:00.000Z',
+    multipliers: [],
+    players: players.map((player) => ({
+      ...player,
+      baseAvgPrice: 0,
+      baseSalesCount: 0,
+      variations: [],
+    })),
+  }
+}
+
+describe('Fanatics scope options', () => {
+  it('builds sorted, deduplicated player, team, and set suggestions', () => {
+    const options = buildFanaticsScopeOptions([
+      model('bowman-chrome', [
+        { playerName: 'Aiva Arquette', team: 'Miami Marlins' },
+        { playerName: 'Eli Willits', team: 'Washington Nationals' },
+      ]),
+      model('bowman-draft', [
+        { playerName: 'Aiva Arquette', team: 'Miami Marlins' },
+        { playerName: 'Luis Arana', team: null },
+      ]),
+    ])
+
+    expect(options.player).toEqual(['Aiva Arquette', 'Eli Willits', 'Luis Arana'])
+    expect(options.team).toEqual(['Miami Marlins', 'Washington Nationals'])
+    expect(options.set).toEqual(['2026 Bowman Chrome', '2026 Bowman Draft'])
+  })
+
+  it('matches only players with an explicit resolved team', () => {
+    const models = [model('bowman-chrome', [
+      { playerName: 'Aiva Arquette', team: 'MIA' },
+      { playerName: 'Eli Willits', team: 'WSH' },
+      { playerName: 'Unknown Team Player', team: null },
+    ])]
+    const labels: Record<string, string> = { MIA: 'Miami Marlins', WSH: 'Washington Nationals' }
+
+    expect(fanaticsScopedPlayerNames(
+      models,
+      'team',
+      'Miami Marlins',
+      (_playerName, team) => labels[String(team)] ?? '',
+    )).toEqual(['Aiva Arquette'])
+  })
+})

--- a/src/lib/fanaticsScopeOptions.ts
+++ b/src/lib/fanaticsScopeOptions.ts
@@ -1,0 +1,64 @@
+import type { ChecklistModel } from '../types'
+
+export type FanaticsScopeOptions = {
+  player: string[]
+  team: string[]
+  set: string[]
+}
+
+function uniqueSorted(values: Array<string | null | undefined>) {
+  const canonical = new Map<string, string>()
+  for (const rawValue of values) {
+    const value = rawValue?.trim()
+    if (!value) continue
+    const key = value.toLocaleLowerCase()
+    if (!canonical.has(key)) canonical.set(key, value)
+  }
+  return [...canonical.values()].sort((left, right) => left.localeCompare(right))
+}
+
+function normalized(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function releaseLabel(model: ChecklistModel) {
+  const product = model.release.replace(/-/g, ' ').replace(/\s+/g, ' ').trim()
+  const title = product.replace(/\b\w/g, (letter) => letter.toUpperCase())
+  return title.startsWith(String(model.releaseYear)) ? title : `${model.releaseYear} ${title}`
+}
+
+export function buildFanaticsScopeOptions(
+  models: ChecklistModel[],
+  teamForPlayer: (playerName: string, checklistTeam?: string | null) => string = (_playerName, checklistTeam) => checklistTeam ?? '',
+): FanaticsScopeOptions {
+  return {
+    player: uniqueSorted(models.flatMap((model) => model.players.map((player) => player.playerName))),
+    team: uniqueSorted(models.flatMap((model) => model.players.map((player) => teamForPlayer(player.playerName, player.team)))),
+    set: uniqueSorted(models.map(releaseLabel)),
+  }
+}
+
+export function fanaticsScopedPlayerNames(
+  models: ChecklistModel[],
+  scopeType: 'player' | 'team',
+  scopeValue: string,
+  teamForPlayer: (playerName: string, checklistTeam?: string | null) => string = (_playerName, checklistTeam) => checklistTeam ?? '',
+) {
+  const scopeKey = normalized(scopeValue)
+  if (!scopeKey) return []
+  return uniqueSorted(models.flatMap((model) => model.players.flatMap((player) => {
+    const candidate = normalized(
+      scopeType === 'team' ? teamForPlayer(player.playerName, player.team) : player.playerName,
+    )
+    if (!candidate) return []
+    const matches = scopeType === 'team'
+      ? candidate === scopeKey
+      : candidate === scopeKey || candidate.includes(scopeKey) || scopeKey.includes(candidate)
+    return matches ? [player.playerName] : []
+  })))
+}


### PR DESCRIPTION
## What changed

- Adds checklist-derived autocomplete options for Fanatics player, team, and set searches.
- Enriches team choices from prospect-ranking metadata and displays canonical MLB team names.
- Expands a selected team only to players with an explicit matching team.
- Memoizes the large option list to avoid rebuilding it on unrelated filter changes.

## Why

Team scanning existed as free text, but users had to guess valid spellings and missing team metadata could over-broaden a search.

## Validation

- `npm run check` (224 tests, lint, TypeScript, production build)
- Browser-verified 31 team options and zero console errors
- Unit coverage confirms players without team data cannot leak into team results