### PR TITLE
Expand Fanatics scans across all Bowman checklists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
 } from './lib/ebay'
 import {
   fetchFanaticsCollectBinListings,
+  fetchFanaticsCollectChecklistListings,
   fetchFanaticsCollectStatus,
   fetchFanaticsCollectWideListings,
   type FanaticsCollectScopeType,
@@ -624,7 +625,7 @@ const FALLBACK_RELEASE_OPTIONS: ReleaseOption[] = [
 ]
 
 const CHECKLIST_CATEGORIES: ChecklistModel['category'][] = ['bowman', 'chrome', 'draft']
-const CHECKLIST_MIN_YEAR = 2020
+const CHECKLIST_MIN_YEAR = 2016
 const CHECKLIST_LOAD_CONCURRENCY = 6
 const BIN_SCAN_CONCURRENCY = 2
 const LEADERBOARD_RENDER_LIMIT = 25
@@ -6420,7 +6421,8 @@ function BinRadar({
 }) {
   const ebayConfigured = Boolean(ebayStatus?.configured)
   const fanaticsTargetedConfigured = Boolean(fanaticsStatus?.targetedSearch?.configured)
-  const fanaticsWideConfigured = Boolean(fanaticsStatus?.wideScan?.configured)
+  const fanaticsFeedConfigured = Boolean(fanaticsStatus?.wideScan?.configured)
+  const fanaticsWideConfigured = fanaticsFeedConfigured || fanaticsTargetedConfigured
   const targetedConfigured = ebayConfigured || fanaticsTargetedConfigured
   const configured = targetedConfigured || fanaticsWideConfigured
   const latestFetchedAt = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleTimeString() : null
@@ -6552,10 +6554,10 @@ function BinRadar({
               ? 'eBay + Fanatics'
               : ebayConfigured
                 ? 'eBay live'
-                : fanaticsWideConfigured
-                  ? 'Fanatics authorized feed'
+                : fanaticsFeedConfigured
+                  ? 'Fanatics full inventory'
                   : fanaticsTargetedConfigured
-                    ? 'Fanatics targeted search'
+                    ? 'Fanatics full checklist search'
                     : 'Marketplace unavailable'}
           </span>
           {configured ? <span className={ebayStatus?.cache?.enabled ? 'connected' : 'offline'}>{browseCacheLabel}</span> : null}
@@ -6600,12 +6602,18 @@ function BinRadar({
           type="button"
           onClick={onScanFanaticsWide}
           disabled={!canScanFanaticsWide}
-          title={fanaticsStatus?.wideScan?.message}
+          title={
+            fanaticsFeedConfigured
+              ? fanaticsStatus?.wideScan?.message
+              : fanaticsTargetedConfigured
+                ? 'Search every loaded checklist through the authorized Fanatics search connection.'
+                : fanaticsStatus?.message
+          }
         >
           <ScanSearch size={17} />
           <span>
             <strong>Wide Fanatics sweep</strong>
-            <small>{fanaticsWideConfigured ? `All ${playerCount.toLocaleString()} loaded player lanes` : 'Requires approved Fanatics data access'}</small>
+            <small>{fanaticsWideConfigured ? `${playerCount.toLocaleString()} loaded player lanes · cached 24h` : 'Requires approved Fanatics data access'}</small>
           </span>
         </button>
         <button className="preset-scan-card primary-preset" type="button" onClick={onScanValueTargets} disabled={!canScanValueTargets}>
@@ -10417,10 +10425,11 @@ function App() {
       setBinError('No checklist models are loaded for the Fanatics wide scan.')
       return
     }
-    if (!fanaticsStatus?.wideScan?.configured) {
+    const feedConfigured = Boolean(fanaticsStatus?.wideScan?.configured)
+    const checklistSearchConfigured = Boolean(fanaticsStatus?.targetedSearch?.configured)
+    if (!feedConfigured && !checklistSearchConfigured) {
       setBinError(
-        fanaticsStatus?.wideScan?.message ??
-          'Fanatics Collect wide scan requires an approved data feed and written data-access permission.',
+        fanaticsStatus?.message ?? 'Fanatics Collect search is not configured.',
       )
       return
     }
@@ -10441,12 +10450,19 @@ function App() {
     setLastRejectedListing(null)
 
     try {
-      const scanResult = await fetchFanaticsCollectWideListings({
-        models: scanModels,
-        minPrice: binMinPrice,
-        maxPages: fanaticsStatus.wideScan.maxPages,
-        signal: controller.signal,
-      })
+      const scanResult = feedConfigured
+        ? await fetchFanaticsCollectWideListings({
+            models: scanModels,
+            minPrice: binMinPrice,
+            maxPages: fanaticsStatus?.wideScan?.maxPages,
+            signal: controller.signal,
+          })
+        : await fetchFanaticsCollectChecklistListings({
+            models: scanModels,
+            minPrice: binMinPrice,
+            limitPerPlayer: 16,
+            signal: controller.signal,
+          })
       if (controller.signal.aborted) return
       const visibleScanResult = filterRejectedScanResult(scanResult, rejectedListingKeys)
       setBinListings(scanResult.listings)
@@ -10469,7 +10485,7 @@ function App() {
         playerScope: 'all',
         playerNames: [],
         searchMode: 'checklist',
-        searchTerm: 'authorized-fanatics-wide-feed',
+        searchTerm: feedConfigured ? 'authorized-fanatics-wide-feed' : 'authorized-fanatics-checklist-sweep',
         salesCacheModels: scanSalesCacheModels,
       })
     } catch (scanError) {
@@ -11411,6 +11427,7 @@ function App() {
           error={binError}
           scopeOptions={fanaticsScopeOptions}
           onSearch={(scopeType, scopeValue) => void searchFanaticsCollectScope(scopeType, scopeValue)}
+          onRunWideScan={() => void scanFanaticsCollectWide('fanatics')}
         />
       ) : workMode === 'price' ? (
         <section className="price-workflow" aria-label="Price my card">

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -88,6 +88,7 @@ export function FanaticsCollectPage({
   error,
   scopeOptions,
   onSearch,
+  onRunWideScan,
 }: {
   opportunities: Opportunity[]
   scan: EbayBinScanResult | null
@@ -96,6 +97,7 @@ export function FanaticsCollectPage({
   error: string | null
   scopeOptions: FanaticsScopeOptions
   onSearch: (scopeType: FanaticsCollectScopeType, scopeValue: string) => void
+  onRunWideScan: () => void
 }) {
   const [filterQuery, setFilterQuery] = useState('')
   const [scopeType, setScopeType] = useState<FanaticsCollectScopeType>('player')
@@ -108,6 +110,7 @@ export function FanaticsCollectPage({
   const [holdsOnly, setHoldsOnly] = useState(false)
   const [holdTargets, setHoldTargets] = useState<string[]>(readHoldTargets)
   const searchReady = Boolean(status?.targetedSearch?.configured)
+  const wideSearchReady = searchReady || Boolean(status?.wideScan?.configured)
   const fanaticsOpportunities = useMemo(
     () => opportunities.filter((opportunity) => opportunity.listing.marketplace === 'fanatics-collect'),
     [opportunities],
@@ -166,9 +169,13 @@ export function FanaticsCollectPage({
             Fanatics Collect · Bowman prospect autos
           </span>
           <h2>Collect finds, without the clunky hunt.</h2>
-          <p>See every matched card within 50% of model, then narrow the board or save the players you want to hold.</p>
+          <p>Scan every loaded Bowman checklist, or focus on one player, team, or set. Every matched listing is ranked against model value.</p>
         </div>
         <div className="fanatics-scope-panel">
+        <button className="fanatics-scan-button" type="button" onClick={onRunWideScan} disabled={!wideSearchReady || loading}>
+          <RefreshCw size={17} className={loading ? 'spin' : undefined} />
+          {loading ? 'Scanning all checklists' : 'Scan all Bowman checklists'}
+        </button>
         <form className="fanatics-scope-search" onSubmit={submitScope}>
           <select
             value={scopeType}
@@ -198,7 +205,7 @@ export function FanaticsCollectPage({
           </button>
         </form>
         <small className="fanatics-scope-count">
-          {activeScopeOptions.length.toLocaleString()} {scopeType === 'set' ? 'sets' : `${scopeType}s`} available
+          Or focus the search · {activeScopeOptions.length.toLocaleString()} {scopeType === 'set' ? 'sets' : `${scopeType}s`} available
         </small>
         </div>
       </header>
@@ -218,7 +225,7 @@ export function FanaticsCollectPage({
         <span><strong>{fanaticsOpportunities.length.toLocaleString()}</strong> modeled listings</span>
         <span><strong>{withinModelWindowCount.toLocaleString()}</strong> within 50% of model</span>
         <span><strong>{holdTargets.length.toLocaleString()}</strong> hold targets</span>
-        <span><strong>{scan?.stats.upstreamPagesFetched.toLocaleString() ?? '0'}</strong> feed pages</span>
+        <span><strong>{scan?.stats.upstreamPagesFetched.toLocaleString() ?? '0'}</strong> source batches</span>
         <span>{latestLabel}</span>
       </div>
 
@@ -294,7 +301,7 @@ export function FanaticsCollectPage({
       {filtered.length === 0 ? (
         <div className="fanatics-empty">
           <Target size={25} />
-          <strong>{scan ? 'No cards match these filters.' : 'Search a player, team, or set to build this board.'}</strong>
+          <strong>{scan ? 'No cards match these filters.' : 'Scan all checklists or choose a focused search.'}</strong>
           <span>{scan ? 'Try the all-listings view, remove the price cap, or enter another scope.' : 'We’ll rank every matched result against the Backstop model.'}</span>
         </div>
       ) : (

--- a/src/lib/fanaticsCollect.test.ts
+++ b/src/lib/fanaticsCollect.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChecklistModel } from '../types'
-import { mapAuthorizedFanaticsCollectInventory } from './fanaticsCollect'
+import { fetchFanaticsCollectBinListings, mapAuthorizedFanaticsCollectInventory } from './fanaticsCollect'
 
 function model(
   release: string,
@@ -27,6 +27,11 @@ function model(
 const bowman2026 = model('2026-Bowman', 2026, 'bowman', ['Aiva Arquette', 'Luis Arana'])
 const chrome2025 = model('2025-Bowman-Chrome', 2025, 'chrome', ['Aiva Arquette', 'Jesus Made'])
 const draft2025 = model('2025-Bowman-Draft', 2025, 'draft', ['Eli Willits'])
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 describe('authorized Fanatics Collect inventory matcher', () => {
   it('maps an active fixed-price Bowman auto to one checklist model with a namespaced identity', () => {
@@ -125,5 +130,58 @@ describe('authorized Fanatics Collect inventory matcher', () => {
       'fanatics-collect:copy-one',
       'fanatics-collect:copy-two',
     ])
+  })
+})
+
+describe('Fanatics Collect checklist retrieval', () => {
+  it('batches beyond the server query ceiling without dropping players', async () => {
+    const players = Array.from({ length: 125 }, (_, index) => `Test Player ${index + 1}`)
+    const largeModel = model('2026-Bowman', 2026, 'bowman', players)
+    const batchSizes: number[] = []
+    const scopes: unknown[] = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { queries: Array<{ playerName: string }>; scope?: unknown }
+      batchSizes.push(body.queries.length)
+      scopes.push(body.scope)
+      return Response.json({
+        items: body.queries.map((query, index) => ({
+          listingUuid: `${query.playerName}-${index}`,
+          title: `2026 Bowman Chrome ${query.playerName} 1st Auto`,
+          askingPrice: 25,
+          status: 'Live',
+          marketplace: 'FIXED',
+          year: 2026,
+          _backstopQuery: { ...query, release: largeModel.release, releaseYear: 2026, category: 'bowman' },
+        })),
+        fetchedAt: '2026-07-11T12:00:00.000Z',
+        stats: {
+          queriesRun: body.queries.length,
+          queriesSucceeded: body.queries.length,
+          queriesFailed: 0,
+          pagesFetched: body.queries.length,
+          upstreamTotal: body.queries.length,
+          dedupedItems: body.queries.length,
+          cacheHits: 0,
+          cacheMisses: 0,
+          cacheWrites: 1,
+          cacheSkips: 0,
+          redisCacheHits: 0,
+          runtimeCacheHits: 0,
+          sqliteCacheHits: 0,
+          upstreamPagesFetched: 1,
+        },
+      })
+    }))
+
+    const result = await fetchFanaticsCollectBinListings({ model: largeModel, playerLimit: null })
+
+    expect(batchSizes).toEqual([120, 5])
+    expect(scopes).toEqual([
+      { type: 'set', value: '2026 Bowman' },
+      { type: 'set', value: '2026 Bowman' },
+    ])
+    expect(result.stats.queriesRun).toBe(125)
+    expect(result.listings).toHaveLength(125)
+    expect(new Set(result.listings.map((listing) => listing.player_name)).size).toBe(125)
   })
 })

--- a/src/lib/fanaticsCollect.ts
+++ b/src/lib/fanaticsCollect.ts
@@ -182,6 +182,28 @@ type FetchFanaticsCollectListingsOptions = {
   }
 }
 
+const FANATICS_CLIENT_QUERY_BATCH_SIZE = 120
+const FANATICS_CLIENT_BATCH_CONCURRENCY = 3
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+) {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  await Promise.all(
+    Array.from({ length: Math.min(Math.max(1, concurrency), items.length) }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex
+        nextIndex += 1
+        results[index] = await mapper(items[index], index)
+      }
+    }),
+  )
+  return results
+}
+
 function numberValue(value: unknown, fallback = 0) {
   const parsed =
     typeof value === 'number'
@@ -779,20 +801,71 @@ export async function fetchFanaticsCollectBinListings(options: FetchFanaticsColl
         ],
   )
 
-  const response = await fetch('/api/fanatics-collect/search', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    signal: options.signal,
-    body: JSON.stringify({
-      queries,
-      scope: options.scope,
-      minPrice: options.minPrice ?? 0,
-      limit: options.limitPerPlayer ?? 40,
-    }),
-  })
-
-  const payload = (await response.json()) as FanaticsCollectSearchResponse
-  if (!response.ok) throw new Error(payload.error ?? 'Fanatics Collect search failed')
+  // A single server request is deliberately bounded. Split large checklist
+  // scopes here so players beyond that ceiling are never silently omitted.
+  const queryBatches: FanaticsCollectQueryMeta[][] = []
+  for (let index = 0; index < queries.length; index += FANATICS_CLIENT_QUERY_BATCH_SIZE) {
+    queryBatches.push(queries.slice(index, index + FANATICS_CLIENT_QUERY_BATCH_SIZE))
+  }
+  const batchResults = await mapWithConcurrency(
+    queryBatches,
+    FANATICS_CLIENT_BATCH_CONCURRENCY,
+    async (batch) => {
+      try {
+        const response = await fetch('/api/fanatics-collect/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          signal: options.signal,
+          body: JSON.stringify({
+            queries: batch,
+            scope: options.scope ?? {
+              type: 'set',
+              value: `${options.model.releaseYear} ${releaseProductLabel(options.model)}`,
+            },
+            minPrice: options.minPrice ?? 0,
+            limit: options.limitPerPlayer ?? 40,
+          }),
+        })
+        const payload = (await response.json()) as FanaticsCollectSearchResponse
+        if (!response.ok) throw new Error(payload.error ?? 'Fanatics Collect search failed')
+        return { payload, error: null as string | null }
+      } catch (error) {
+        if (options.signal?.aborted) throw error
+        return {
+          payload: null,
+          error: error instanceof Error ? error.message : 'Fanatics Collect search batch failed',
+        }
+      }
+    },
+  )
+  const successfulPayloads = batchResults.flatMap((result) => (result.payload ? [result.payload] : []))
+  if (successfulPayloads.length === 0) {
+    throw new Error(batchResults.find((result) => result.error)?.error ?? 'Fanatics Collect search failed')
+  }
+  const batchErrors = batchResults.flatMap((result, index) =>
+    result.error ? [{ query: `Fanatics batch ${index + 1}`, error: result.error }] : [],
+  )
+  const payload: FanaticsCollectSearchResponse = {
+    items: successfulPayloads.flatMap((result) => result.items ?? []),
+    errors: [...successfulPayloads.flatMap((result) => result.errors ?? []), ...batchErrors],
+    fetchedAt: successfulPayloads.map((result) => result.fetchedAt ?? '').filter(Boolean).sort().at(-1) ?? new Date().toISOString(),
+    stats: {
+      queriesRun: successfulPayloads.reduce((total, result) => total + (result.stats?.queriesRun ?? 0), 0),
+      queriesSucceeded: successfulPayloads.reduce((total, result) => total + (result.stats?.queriesSucceeded ?? 0), 0),
+      queriesFailed: successfulPayloads.reduce((total, result) => total + (result.stats?.queriesFailed ?? 0), 0) + batchErrors.length,
+      pagesFetched: successfulPayloads.reduce((total, result) => total + (result.stats?.pagesFetched ?? 0), 0),
+      upstreamTotal: successfulPayloads.reduce((total, result) => total + (result.stats?.upstreamTotal ?? 0), 0),
+      dedupedItems: successfulPayloads.reduce((total, result) => total + (result.stats?.dedupedItems ?? 0), 0),
+      cacheHits: successfulPayloads.reduce((total, result) => total + (result.stats?.cacheHits ?? 0), 0),
+      cacheMisses: successfulPayloads.reduce((total, result) => total + (result.stats?.cacheMisses ?? 0), 0),
+      cacheWrites: successfulPayloads.reduce((total, result) => total + (result.stats?.cacheWrites ?? 0), 0),
+      cacheSkips: successfulPayloads.reduce((total, result) => total + (result.stats?.cacheSkips ?? 0), 0),
+      redisCacheHits: successfulPayloads.reduce((total, result) => total + (result.stats?.redisCacheHits ?? 0), 0),
+      runtimeCacheHits: successfulPayloads.reduce((total, result) => total + (result.stats?.runtimeCacheHits ?? 0), 0),
+      sqliteCacheHits: successfulPayloads.reduce((total, result) => total + (result.stats?.sqliteCacheHits ?? 0), 0),
+      upstreamPagesFetched: successfulPayloads.reduce((total, result) => total + (result.stats?.upstreamPagesFetched ?? 0), 0),
+    },
+  }
 
   const fallbackReleaseLabel = releaseProductLabel(options.model)
   let rejectedPlayerMismatches = 0
@@ -828,6 +901,71 @@ export async function fetchFanaticsCollectBinListings(options: FetchFanaticsColl
       runtimeCacheHits: payload.stats?.runtimeCacheHits ?? 0,
       sqliteCacheHits: payload.stats?.sqliteCacheHits ?? 0,
       upstreamPagesFetched: payload.stats?.upstreamPagesFetched ?? payload.stats?.pagesFetched ?? 0,
+    },
+  }
+}
+
+export async function fetchFanaticsCollectChecklistListings(options: {
+  models: ChecklistModel[]
+  minPrice?: number
+  limitPerPlayer?: number
+  signal?: AbortSignal
+}): Promise<EbayBinScanResult> {
+  const models = options.models.filter((model) => model.players.length > 0)
+  if (models.length === 0) throw new Error('No checklist models are loaded for the Fanatics scan.')
+
+  const results = await mapWithConcurrency(models, 3, async (model) => {
+    try {
+      return {
+        scan: await fetchFanaticsCollectBinListings({
+          model,
+          minPrice: options.minPrice,
+          playerLimit: null,
+          limitPerPlayer: options.limitPerPlayer ?? 16,
+          searchMode: 'checklist',
+          signal: options.signal,
+        }),
+        error: null as string | null,
+      }
+    } catch (error) {
+      if (options.signal?.aborted) throw error
+      return {
+        scan: null,
+        error: error instanceof Error ? error.message : `${model.release} Fanatics scan failed`,
+      }
+    }
+  })
+  const scans = results.flatMap((result) => (result.scan ? [result.scan] : []))
+  if (scans.length === 0) {
+    throw new Error(results.find((result) => result.error)?.error ?? 'Fanatics checklist scan failed')
+  }
+
+  const listings = dedupeListings(scans.flatMap((scan) => scan.listings))
+  const errors = [
+    ...scans.flatMap((scan) => scan.errors),
+    ...results.flatMap((result, index) => result.error ? [{ query: models[index]?.release, error: result.error }] : []),
+  ]
+  return {
+    listings,
+    fetchedAt: scans.map((scan) => scan.fetchedAt).sort().at(-1) ?? new Date().toISOString(),
+    errors,
+    stats: {
+      queriesRun: scans.reduce((total, scan) => total + scan.stats.queriesRun, 0),
+      queriesSucceeded: scans.reduce((total, scan) => total + scan.stats.queriesSucceeded, 0),
+      queriesFailed: scans.reduce((total, scan) => total + scan.stats.queriesFailed, 0) + results.length - scans.length,
+      pagesFetched: scans.reduce((total, scan) => total + scan.stats.pagesFetched, 0),
+      upstreamTotal: scans.reduce((total, scan) => total + scan.stats.upstreamTotal, 0),
+      dedupedItems: listings.length,
+      mappedListings: listings.length,
+      rejectedPlayerMismatches: scans.reduce((total, scan) => total + scan.stats.rejectedPlayerMismatches, 0),
+      cacheHits: scans.reduce((total, scan) => total + scan.stats.cacheHits, 0),
+      cacheMisses: scans.reduce((total, scan) => total + scan.stats.cacheMisses, 0),
+      cacheWrites: scans.reduce((total, scan) => total + scan.stats.cacheWrites, 0),
+      cacheSkips: scans.reduce((total, scan) => total + scan.stats.cacheSkips, 0),
+      redisCacheHits: scans.reduce((total, scan) => total + scan.stats.redisCacheHits, 0),
+      runtimeCacheHits: scans.reduce((total, scan) => total + scan.stats.runtimeCacheHits, 0),
+      sqliteCacheHits: scans.reduce((total, scan) => total + scan.stats.sqliteCacheHits, 0),
+      upstreamPagesFetched: scans.reduce((total, scan) => total + scan.stats.upstreamPagesFetched, 0),
     },
   }
 }


### PR DESCRIPTION
## Summary
- add a one-click Fanatics sweep across every loaded Bowman checklist
- expand the active universe from 2020+ to 2016+
- batch large searches so the server query ceiling never drops players
- apply an exact set scope to every shared Live Deals request
- retain focused player, team, and set searches
- reuse identical query batches from the 24-hour Redis cache

## Verification
- 35 test files / 229 tests pass
- lint, TypeScript, and production build pass
- live Fanatics probe returned listings successfully
- mobile browser check: no overflow, overlays, or console errors