### PR TITLE
Harden Fanatics marketplace caching

### DIFF
--- a/server/fanaticsCollect.test.ts
+++ b/server/fanaticsCollect.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { handleFanaticsCollectRoute } from './proxy'
 
+const redisMemory = vi.hoisted(() => new Map<string, unknown>())
+
+vi.mock('@upstash/redis', () => ({
+  Redis: class {
+    async get<T>(key: string) {
+      return (redisMemory.get(key) ?? null) as T | null
+    }
+
+    async set(key: string, value: unknown) {
+      redisMemory.set(key, value)
+      return 'OK'
+    }
+  },
+}))
+
 function postJson(body: unknown, route = 'search', includeScope = true) {
   const scopedBody = route === 'search' && includeScope && body && typeof body === 'object'
     ? { scope: { type: 'player', value: 'Aiva Arquette' }, ...body }
@@ -27,6 +42,7 @@ function fanaticsEnv(overrides: Record<string, string | undefined> = {}) {
 }
 
 afterEach(() => {
+  redisMemory.clear()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -168,6 +184,90 @@ describe('Fanatics Collect proxy', () => {
       scopeType: 'player',
       scopeValue: 'Aiva Arquette',
     })
+  })
+
+  it('keeps a stale rescue snapshot and serves it when a live refresh fails', async () => {
+    const env = fanaticsEnv({
+      FANATICS_COLLECT_GRAPHQL_URL: 'https://fanatics-stale.test/graphql',
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'redis-token',
+      FANATICS_QUERY_CACHE_FRESH_TTL_SECONDS: '60',
+      FANATICS_QUERY_CACHE_STALE_TTL_SECONDS: '3600',
+    })
+    const requestBody = {
+      queries: ['Aiva Arquette 2026 Bowman Chrome Auto'],
+      scope: { type: 'player', value: 'Aiva Arquette' },
+      minPrice: 25,
+    }
+    const liveFetch = vi.fn(async (url: string | URL | Request) => {
+      if (String(url) === 'https://fanatics-stale.test/graphql') {
+        return Response.json({ data: { collectSearchKey: 'stale-test-key' } })
+      }
+      return Response.json({
+        results: [{
+          nbHits: 1,
+          hits: [{ objectID: 'aiva-stale', listingUuid: 'aiva-stale', title: 'Aiva Arquette 2026 Bowman Chrome Auto', askingPrice: 50 }],
+        }],
+      })
+    })
+    vi.stubGlobal('fetch', liveFetch)
+
+    const liveResponse = await handleFanaticsCollectRoute('search', postJson(requestBody), env)
+    expect(liveResponse.status).toBe(200)
+    expect(redisMemory.size).toBe(1)
+
+    const [cacheKey, cachedRaw] = [...redisMemory.entries()][0]
+    const cached = JSON.parse(String(cachedRaw)) as { fetchedAt: string }
+    cached.fetchedAt = new Date(Date.now() - 2 * 60 * 1_000).toISOString()
+    redisMemory.set(cacheKey, JSON.stringify(cached))
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 503 })))
+
+    const fallbackResponse = await handleFanaticsCollectRoute('search', postJson(requestBody), env)
+    const fallback = (await fallbackResponse.json()) as {
+      items: unknown[]
+      errors: Array<{ error: string }>
+      cache: { state: string; ageSeconds: number; freshTtlSeconds: number; staleTtlSeconds: number }
+      stats: { upstreamPagesFetched: number; redisCacheHits: number }
+    }
+
+    expect(fallbackResponse.status).toBe(200)
+    expect(fallback.items).toHaveLength(1)
+    expect(fallback.cache).toMatchObject({ state: 'stale-fallback', freshTtlSeconds: 60, staleTtlSeconds: 3600 })
+    expect(fallback.cache.ageSeconds).toBeGreaterThanOrEqual(120)
+    expect(fallback.errors.at(-1)?.error).toMatch(/cached Fanatics results because the live refresh failed/i)
+    expect(fallback.stats).toMatchObject({ upstreamPagesFetched: 0, redisCacheHits: 1 })
+  })
+
+  it('coalesces simultaneous identical searches into one upstream request', async () => {
+    let algoliaCalls = 0
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      if (String(url) === 'https://fanatics-coalesce.test/graphql') {
+        return Response.json({ data: { collectSearchKey: 'coalesce-test-key' } })
+      }
+      algoliaCalls += 1
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      return Response.json({
+        results: [{
+          nbHits: 1,
+          hits: [{ objectID: 'aiva-coalesced', listingUuid: 'aiva-coalesced', title: 'Aiva Arquette 2026 Bowman Chrome Auto', askingPrice: 50 }],
+        }],
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const env = fanaticsEnv({ FANATICS_COLLECT_GRAPHQL_URL: 'https://fanatics-coalesce.test/graphql' })
+    const body = {
+      queries: ['Aiva Arquette 2026 Bowman Chrome Auto'],
+      scope: { type: 'player', value: 'Aiva Arquette' },
+    }
+
+    const [left, right] = await Promise.all([
+      handleFanaticsCollectRoute('search', postJson(body), env),
+      handleFanaticsCollectRoute('search', postJson(body), env),
+    ])
+
+    expect(left.status).toBe(200)
+    expect(right.status).toBe(200)
+    expect(algoliaCalls).toBe(1)
   })
 
   it('paginates an authorized wide feed, deduplicates UUIDs, and reports complete coverage', async () => {

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -38,6 +38,7 @@ const FANATICS_COLLECT_QUERY_CACHE_NAMESPACE = 'backstop-fanatics-collect-query-
 const FANATICS_COLLECT_SEARCH_KEY_TTL_MS = 10 * 60 * 1000
 const FANATICS_COLLECT_QUERY_BATCH_SIZE = 25
 const FANATICS_COLLECT_QUERY_CACHE_TTL_SECONDS = 24 * 60 * 60
+const FANATICS_COLLECT_QUERY_CACHE_STALE_TTL_SECONDS = 3 * 24 * 60 * 60
 const FANATICS_COLLECT_TERMS_URL = 'https://support.fanaticscollect.com/en_us/terms-of-use-r11C70QTge'
 const FANATICS_COLLECT_WIDE_DEFAULT_PAGE_SIZE = 250
 const FANATICS_COLLECT_WIDE_DEFAULT_MAX_PAGES = 40
@@ -4383,12 +4384,20 @@ type FanaticsCollectSearchResult = {
   errors: Array<{ query?: string; error: string }>
   fetchedAt: string
   stats: EbayQueryCacheStats
+  cache?: {
+    state: 'live' | 'fresh' | 'stale-fallback'
+    ageSeconds: number
+    freshTtlSeconds: number
+    staleTtlSeconds: number
+  }
   provenance?: {
     mode: 'authorized-targeted-search' | 'user-scoped-search'
     scopeType: string
     scopeValue: string
   }
 }
+
+const fanaticsCollectInFlightSearches = new Map<string, Promise<FanaticsCollectSearchResult>>()
 
 type FanaticsCollectWideScanPayload = {
   minPrice?: number | string
@@ -4602,6 +4611,28 @@ function dedupeFanaticsCollectHits(items: Array<Record<string, unknown>>) {
   return deduped
 }
 
+function fanaticsCollectCachePolicy(env: ServerEnv) {
+  const freshTtlSeconds = clampInt(
+    env.FANATICS_QUERY_CACHE_FRESH_TTL_SECONDS ?? env.FANATICS_QUERY_CACHE_TTL_SECONDS,
+    FANATICS_COLLECT_QUERY_CACHE_TTL_SECONDS,
+    0,
+    24 * 60 * 60,
+  )
+  const staleTtlSeconds = clampInt(
+    env.FANATICS_QUERY_CACHE_STALE_TTL_SECONDS,
+    FANATICS_COLLECT_QUERY_CACHE_STALE_TTL_SECONDS,
+    freshTtlSeconds,
+    7 * 24 * 60 * 60,
+  )
+  return { freshTtlSeconds, staleTtlSeconds }
+}
+
+function fanaticsCollectCacheAgeSeconds(payload: Pick<FanaticsCollectSearchResult, 'fetchedAt'>) {
+  const fetchedAt = Date.parse(payload.fetchedAt)
+  if (!Number.isFinite(fetchedAt)) return Number.POSITIVE_INFINITY
+  return Math.max(0, Math.floor((Date.now() - fetchedAt) / 1_000))
+}
+
 async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env: ServerEnv): Promise<FanaticsCollectSearchResult> {
   const searchAccess = requireFanaticsCollectSearchAuthorization(env, payload)
   const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
@@ -4648,19 +4679,17 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
   }))
 
   const redis = await getUpstashRedis(env)
-  const cacheTtlSeconds = clampInt(
-    env.FANATICS_QUERY_CACHE_TTL_SECONDS,
-    FANATICS_COLLECT_QUERY_CACHE_TTL_SECONDS,
-    0,
-    24 * 60 * 60,
-  )
+  const cachePolicy = fanaticsCollectCachePolicy(env)
   const cacheKey =
-    redis && cacheTtlSeconds > 0
+    redis && cachePolicy.staleTtlSeconds > 0
       ? redisQueryCacheKey(
           FANATICS_COLLECT_QUERY_CACHE_NAMESPACE,
-          sha256(stableJson({ appId, indexName, requests, version: 1 })),
+          sha256(stableJson({ appId, indexName, requests, scope: searchAccess.scope, version: 2 })),
         )
       : ''
+  const inFlightKey = cacheKey || sha256(stableJson({ appId, indexName, requests, scope: searchAccess.scope, version: 2 }))
+  let staleCachedPayload: FanaticsCollectSearchResult | null = null
+  let staleCacheAgeSeconds = 0
   if (redis && cacheKey) {
     try {
       const cached = await redis.get<string>(cacheKey)
@@ -4670,14 +4699,31 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
           : ((cached ?? null) as Partial<FanaticsCollectSearchResult> | null)
       if (parsed && typeof parsed === 'object' && Array.isArray(parsed.items) && parsed.stats) {
         const cachedPayload = parsed as FanaticsCollectSearchResult
-        return {
-          ...cachedPayload,
-          stats: {
-            ...cachedPayload.stats,
-            cacheHits: Math.max(queries.length, cachedPayload.stats.cacheHits ?? 0),
-            redisCacheHits: Math.max(queries.length, cachedPayload.stats.redisCacheHits ?? 0),
-            upstreamPagesFetched: 0,
-          },
+        const ageSeconds = fanaticsCollectCacheAgeSeconds(cachedPayload)
+        if (ageSeconds <= cachePolicy.freshTtlSeconds) {
+          return {
+            ...cachedPayload,
+            cache: {
+              state: 'fresh',
+              ageSeconds,
+              ...cachePolicy,
+            },
+            provenance: {
+              mode: searchAccess.mode,
+              scopeType: searchAccess.scope.type,
+              scopeValue: searchAccess.scope.value,
+            },
+            stats: {
+              ...cachedPayload.stats,
+              cacheHits: Math.max(queries.length, cachedPayload.stats.cacheHits ?? 0),
+              redisCacheHits: Math.max(queries.length, cachedPayload.stats.redisCacheHits ?? 0),
+              upstreamPagesFetched: 0,
+            },
+          }
+        }
+        if (ageSeconds <= cachePolicy.staleTtlSeconds) {
+          staleCachedPayload = cachedPayload
+          staleCacheAgeSeconds = ageSeconds
         }
       }
     } catch {
@@ -4685,6 +4731,11 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
     }
   }
 
+  const existingSearch = fanaticsCollectInFlightSearches.get(inFlightKey)
+  if (existingSearch) return existingSearch
+
+  const liveSearch = (async () => {
+  try {
   const searchKey = await fetchFanaticsCollectSearchKey(graphqlUrl)
   const resultBatches: Array<{ hits?: Array<Record<string, unknown>>; nbHits?: number; error?: string }> = []
   for (let index = 0; index < requests.length; index += FANATICS_COLLECT_QUERY_BATCH_SIZE) {
@@ -4733,6 +4784,11 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
     items,
     errors,
     fetchedAt: new Date().toISOString(),
+    cache: {
+      state: 'live' as const,
+      ageSeconds: 0,
+      ...cachePolicy,
+    },
     provenance: {
       mode: searchAccess.mode,
       scopeType: searchAccess.scope.type,
@@ -4746,7 +4802,7 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
       upstreamTotal: results.reduce((total, result) => total + fanaticsCollectNumber(result?.nbHits, 0), 0),
       dedupedItems: items.length,
       cacheHits: 0,
-      cacheMisses: 0,
+      cacheMisses: redis && cacheKey ? queries.length : 0,
       cacheWrites: 0,
       cacheSkips: 0,
       redisCacheHits: 0,
@@ -4758,7 +4814,7 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
 
   if (redis && cacheKey) {
     try {
-      await redis.set(cacheKey, jsonText(response), { ex: cacheTtlSeconds })
+      await redis.set(cacheKey, jsonText(response), { ex: cachePolicy.staleTtlSeconds })
       response.stats.cacheWrites = 1
     } catch {
       response.stats.cacheSkips = 1
@@ -4766,6 +4822,42 @@ async function searchFanaticsCollect(payload: FanaticsCollectSearchPayload, env:
   }
 
   return response
+  } catch (error) {
+    if (!staleCachedPayload) throw error
+    const upstreamMessage = routeErrorMessage(error, 'Fanatics Collect live refresh failed')
+    return {
+      ...staleCachedPayload,
+      errors: [
+        ...(staleCachedPayload.errors ?? []),
+        { error: `Showing ${Math.max(1, Math.round(staleCacheAgeSeconds / 3_600))}h cached Fanatics results because the live refresh failed: ${upstreamMessage}` },
+      ],
+      cache: {
+        state: 'stale-fallback' as const,
+        ageSeconds: staleCacheAgeSeconds,
+        ...cachePolicy,
+      },
+      provenance: {
+        mode: searchAccess.mode,
+        scopeType: searchAccess.scope.type,
+        scopeValue: searchAccess.scope.value,
+      },
+      stats: {
+        ...staleCachedPayload.stats,
+        cacheHits: Math.max(queries.length, staleCachedPayload.stats.cacheHits ?? 0),
+        redisCacheHits: Math.max(queries.length, staleCachedPayload.stats.redisCacheHits ?? 0),
+        upstreamPagesFetched: 0,
+      },
+    }
+  }
+  })()
+  fanaticsCollectInFlightSearches.set(inFlightKey, liveSearch)
+  try {
+    return await liveSearch
+  } finally {
+    if (fanaticsCollectInFlightSearches.get(inFlightKey) === liveSearch) {
+      fanaticsCollectInFlightSearches.delete(inFlightKey)
+    }
+  }
 }
 
 function fanaticsCollectWideItemIdentity(item: Record<string, unknown>) {
@@ -4997,6 +5089,8 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
     }
 
     const authorization = fanaticsCollectAuthorization(env)
+    const cachePolicy = fanaticsCollectCachePolicy(env)
+    const redisConfigured = upstashRedisEnv(env).configured
     const graphqlUrl = env.FANATICS_COLLECT_GRAPHQL_URL?.trim() || FANATICS_COLLECT_GRAPHQL_URL
     let reachable = false
     let message = authorization.issue ?? 'Fanatics Collect search requires written data-access permission.'
@@ -5030,6 +5124,12 @@ export async function handleFanaticsCollectRoute(route: string, request: Request
         configured: reachable,
         reachable,
         mode: authorization.searchAuthorized ? 'authorized-targeted-search' : 'user-scoped-search',
+      },
+      cache: {
+        configured: redisConfigured,
+        backend: redisConfigured ? 'redis' : 'none',
+        freshTtlSeconds: cachePolicy.freshTtlSeconds,
+        staleTtlSeconds: cachePolicy.staleTtlSeconds,
       },
       wideScan: {
         configured: authorization.feedAuthorized,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6472,6 +6472,11 @@ function BinRadar({
       : ebayStatus?.cache?.enabled
         ? 'Browse cache on'
         : 'Browse cache off'
+  const fanaticsFreshHours = Math.round((fanaticsStatus?.cache?.freshTtlSeconds ?? 0) / 3_600)
+  const fanaticsRescueHours = Math.round((fanaticsStatus?.cache?.staleTtlSeconds ?? 0) / 3_600)
+  const fanaticsCacheLabel = fanaticsFreshHours > 0
+    ? `${fanaticsFreshHours}h fresh${fanaticsRescueHours > fanaticsFreshHours ? ` · ${fanaticsRescueHours}h outage rescue` : ''}`
+    : 'shared scan cache'
   const busy = loading || auctionLoading
   const canScan = targetedConfigured && setCount > 0 && hasPlayerUniverse && hasFocus && hasTargetQueue && !busy && !modelLoading
   const canScanBaseAutos = targetedConfigured && setCount > 0 && hasPlayerUniverse && hasTargetQueue && !busy && !modelLoading
@@ -6613,7 +6618,7 @@ function BinRadar({
           <ScanSearch size={17} />
           <span>
             <strong>Wide Fanatics sweep</strong>
-            <small>{fanaticsWideConfigured ? `${playerCount.toLocaleString()} loaded player lanes · cached 24h` : 'Requires approved Fanatics data access'}</small>
+            <small>{fanaticsWideConfigured ? `${playerCount.toLocaleString()} loaded player lanes · ${fanaticsCacheLabel}` : 'Requires approved Fanatics data access'}</small>
           </span>
         </button>
         <button className="preset-scan-card primary-preset" type="button" onClick={onScanValueTargets} disabled={!canScanValueTargets}>

--- a/src/FanaticsCollectPage.tsx
+++ b/src/FanaticsCollectPage.tsx
@@ -30,6 +30,12 @@ function percent(value: number) {
   return `${Math.round(value * 100)}%`
 }
 
+function cacheWindowLabel(seconds?: number) {
+  if (!seconds || seconds <= 0) return null
+  const hours = Math.round(seconds / 3_600)
+  return hours >= 48 && hours % 24 === 0 ? `${hours / 24}d` : `${hours}h`
+}
+
 function readHoldTargets() {
   if (typeof window === 'undefined') return [] as string[]
   try {
@@ -133,6 +139,8 @@ export function FanaticsCollectPage({
     (opportunity) => opportunity.listing.allInPrice <= opportunity.fairValue * 1.5,
   ).length
   const latestLabel = scan?.fetchedAt ? new Date(scan.fetchedAt).toLocaleString() : 'Enter a scope to search'
+  const freshCacheLabel = cacheWindowLabel(status?.cache?.freshTtlSeconds)
+  const rescueCacheLabel = cacheWindowLabel(status?.cache?.staleTtlSeconds)
   const activeScopeOptions = scopeOptions[scopeType]
   const scopeListId = `fanatics-${scopeType}-options`
   const scopeOptionNodes = useMemo(
@@ -226,6 +234,9 @@ export function FanaticsCollectPage({
         <span><strong>{withinModelWindowCount.toLocaleString()}</strong> within 50% of model</span>
         <span><strong>{holdTargets.length.toLocaleString()}</strong> hold targets</span>
         <span><strong>{scan?.stats.upstreamPagesFetched.toLocaleString() ?? '0'}</strong> source batches</span>
+        {status?.cache?.configured && freshCacheLabel ? (
+          <span><strong>{freshCacheLabel}</strong> fresh{rescueCacheLabel ? ` · ${rescueCacheLabel} outage rescue` : ''}</span>
+        ) : null}
         <span>{latestLabel}</span>
       </div>
 

--- a/src/lib/fanaticsCollect.ts
+++ b/src/lib/fanaticsCollect.ts
@@ -88,6 +88,12 @@ type FanaticsCollectSearchResponse = {
   errors?: Array<{ query?: string; error: string }>
   fetchedAt?: string
   stats?: Omit<EbayBinScanResult['stats'], 'mappedListings' | 'rejectedPlayerMismatches'>
+  cache?: {
+    state?: 'live' | 'fresh' | 'stale-fallback'
+    ageSeconds?: number
+    freshTtlSeconds?: number
+    staleTtlSeconds?: number
+  }
   error?: string
 }
 
@@ -109,6 +115,12 @@ export type FanaticsCollectStatus = {
     configured: boolean
     reachable: boolean
     mode?: 'authorized-targeted-search' | 'user-scoped-search'
+  }
+  cache?: {
+    configured: boolean
+    backend: 'redis' | 'none'
+    freshTtlSeconds: number
+    staleTtlSeconds: number
   }
   wideScan?: {
     configured: boolean


### PR DESCRIPTION
## Summary
- keep Fanatics search results fresh for 24 hours and retain a 72-hour outage-rescue snapshot
- coalesce concurrent identical searches and scope cache fingerprints correctly
- expose cache policy in status and UI
- add regression coverage for stale fallback and request coalescing

## Verification
- npm run check (231 tests, lint, typecheck, production build)
- desktop and 390px mobile browser smoke test
- no Vite error overlay