### PR TITLE
Document Fanatics cache windows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,10 @@ FANATICS_COLLECT_SEARCH_AUTHORIZED=false
 FANATICS_COLLECT_GRAPHQL_URL=https://app.fanaticscollect.com/graphql
 FANATICS_COLLECT_ALGOLIA_APP_ID=3XT9C4X62I
 FANATICS_COLLECT_ALGOLIA_INDEX=prod_item_state_v1
-FANATICS_QUERY_CACHE_TTL_SECONDS=86400
+# Fixed-price search results are considered fresh for 24h. Redis retains them
+# for 72h only so an upstream outage can return a clearly labeled fallback.
+FANATICS_QUERY_CACHE_FRESH_TTL_SECONDS=86400
+FANATICS_QUERY_CACHE_STALE_TTL_SECONDS=259200
 
 # Cursor-based authorized wide-feed contract. The URL must return JSON with an
 # items/listings/data array and nextCursor + hasMore fields. Images are stripped

--- a/docs/FANATICS_COLLECT_WIDE_SCAN.md
+++ b/docs/FANATICS_COLLECT_WIDE_SCAN.md
@@ -50,7 +50,15 @@ FANATICS_COLLECT_AUTHORIZED_FEED_TOKEN=<server-side bearer token>
 FANATICS_COLLECT_WIDE_MAX_PAGES=40
 FANATICS_COLLECT_WIDE_TIME_BUDGET_MS=25000
 FANATICS_COLLECT_IMAGE_RIGHTS_AUTHORIZED=false
+FANATICS_QUERY_CACHE_FRESH_TTL_SECONDS=86400
+FANATICS_QUERY_CACHE_STALE_TTL_SECONDS=259200
 ```
+
+Targeted checklist searches use a two-window Redis policy: results are served
+normally during the fresh window, retained through the stale window, and used
+after the fresh window only when a live Fanatics refresh fails. The API labels
+that response `stale-fallback`; the client surfaces the upstream failure rather
+than presenting old inventory as live.
 
 The server sends a `GET` request with these query parameters:
 


### PR DESCRIPTION
Documents the 24-hour fresh and 72-hour outage-rescue cache policy added in #16, including the production environment variable names and stale-response behavior.