### PR TITLE
Reconcile pending data model hardening

### DIFF
--- a/public/access.html
+++ b/public/access.html
@@ -118,17 +118,19 @@
       <img src="/backstop-logo.jpeg" alt="Backstop Cards" />
       <h1>Private Clubhouse</h1>
       <p>Backstop Card Finder is invite-only while the model is still being sharpened.</p>
-      <p class="error">That code did not match. Check it and try again.</p>
+      <p class="error" id="access-error" role="alert" aria-live="assertive">That code did not match. Check it and try again.</p>
       <form method="post" action="/api/access/login">
         <input id="next" name="next" type="hidden" value="/" />
         <label for="code">Access code</label>
-        <input id="code" name="code" type="password" autocomplete="current-password" autofocus required />
+        <input id="code" name="code" type="password" autocomplete="current-password" aria-describedby="access-error" autofocus required />
         <button type="submit">Enter Backstop</button>
       </form>
     </main>
     <script>
       const params = new URLSearchParams(window.location.search)
-      document.body.dataset.error = params.get('error') === '1' ? 'true' : 'false'
+      const hasError = params.get('error') === '1'
+      document.body.dataset.error = hasError ? 'true' : 'false'
+      document.querySelector('#code').setAttribute('aria-invalid', hasError ? 'true' : 'false')
       document.querySelector('#next').value = params.get('next') || '/'
     </script>
   </body>

--- a/scripts/canonical-market.mjs
+++ b/scripts/canonical-market.mjs
@@ -694,6 +694,7 @@ export function rebuildCanonicalMarket(db, options = {}) {
   let cardHedgeNativeMappings = 0
   let structuredMappings = 0
   const useNativeCardHedge = options.useNativeCardHedge ?? hasNativeCardHedgeSales(db)
+  const hasValidReleaseYear = (card) => Number.isInteger(card.releaseYear) && card.releaseYear >= 1900 && card.releaseYear <= 2100
 
   db.prepare(
     `DELETE FROM canonical_source_mappings WHERE source IN (${REBUILT_CANONICAL_SOURCES.map(() => '?').join(', ')})`,
@@ -710,7 +711,7 @@ export function rebuildCanonicalMarket(db, options = {}) {
       const normalized = normalizeCardHedgeNativeSale(row)
       if (!normalized.modelEligible) continue
       const card = canonicalFromNormalizedSale(normalized)
-      if (!card.playerName) continue
+      if (!card.playerName || !hasValidReleaseYear(card)) continue
       upsertCanonicalCard(db, card, nowIso)
       upsertSourceMapping(
         db,
@@ -747,7 +748,7 @@ export function rebuildCanonicalMarket(db, options = {}) {
 
   for (const row of normalizedSaleRows(db, { includeCardHedgeMirror: !useNativeCardHedge })) {
     const card = canonicalFromNormalizedSale(row)
-    if (!card.playerName || !row.itemId) continue
+    if (!card.playerName || !row.itemId || !hasValidReleaseYear(card)) continue
     const sourceName = String(row.source ?? '').startsWith('card-hedge') ? 'card_hedge_sale' : 'market_movers_sale'
     upsertCanonicalCard(db, card, nowIso)
     upsertSourceMapping(
@@ -778,7 +779,7 @@ export function rebuildCanonicalMarket(db, options = {}) {
   const structuredCardKeyToCanonical = new Map()
   for (const row of structuredCardRows(db)) {
     const card = canonicalFromStructuredCard(row)
-    if (!card.playerName || !row.cardKey) continue
+    if (!card.playerName || !row.cardKey || !hasValidReleaseYear(card)) continue
     upsertCanonicalCard(db, card, nowIso)
     upsertSourceMapping(db, 'market_movers_card', row.cardKey, card, parseJson(row.rawJson, {}), 0.82, nowIso)
     structuredCardKeyToCanonical.set(row.cardKey, card.canonicalCardKey)

--- a/scripts/first-bowman-base-auto-projection.mjs
+++ b/scripts/first-bowman-base-auto-projection.mjs
@@ -33,6 +33,28 @@ function tableExists(db, tableName) {
 }
 
 function baseAutoRows(db) {
+  if (tableExists(db, 'canonical_cards') && tableExists(db, 'canonical_comp_summary')) {
+    return db.prepare(`
+      SELECT
+        cc.player_name AS playerName,
+        cc.release_year AS releaseYear,
+        cc.product_family AS productFamily,
+        cc.variation_label AS variationLabel,
+        s.sale_count AS saleCount,
+        s.sales_30 AS sales30,
+        s.sales_90 AS sales90,
+        s.median_price AS medianPrice,
+        COALESCE(NULLIF(s.twma_30, 0), NULLIF(s.recent_5_avg, 0), NULLIF(s.twma_90, 0), NULLIF(s.median_price, 0), NULLIF(s.avg_price, 0), 0) AS modelPrice,
+        s.latest_sold_at AS latestSoldAt
+      FROM canonical_cards cc
+      JOIN canonical_comp_summary s ON s.canonical_card_key = cc.canonical_card_key
+      WHERE cc.grade_bucket = 'Raw'
+        AND cc.card_class IN ('auto', 'paper-auto')
+        AND cc.variation_label IN ('Base Auto', 'Base', '')
+        AND s.sale_count > 0
+      ORDER BY modelPrice DESC
+    `).all()
+  }
   if (!tableExists(db, 'market_movers_model_buckets')) return []
   return db.prepare(`
     SELECT

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -137,6 +137,7 @@ type SqliteStatement = {
 type SqliteDatabase = {
   exec: (sql: string) => void
   prepare: (sql: string) => SqliteStatement
+  function: (name: string, options: { deterministic?: boolean }, callback: (value: unknown) => string) => void
   close: () => void
 }
 type SqliteModule = {
@@ -448,13 +449,28 @@ function salesCacheDbPath(env: ServerEnv) {
   return resolve(env.BACKSTOP_SALES_DB?.trim() || 'local-data/backstop-sales.sqlite')
 }
 
+function normalizePlayerLookup(value: unknown) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function registerPlayerLookup(db: SqliteDatabase) {
+  db.function('normalize_player_lookup', { deterministic: true }, normalizePlayerLookup)
+  return db
+}
+
 async function openSalesCacheDb(env: ServerEnv) {
   const dbPath = salesCacheDbPath(env)
   if (!existsSync(dbPath)) return { db: null, dbPath }
 
   const sqliteSpecifier = 'node:sqlite'
   const sqlite = (await import(sqliteSpecifier)) as unknown as SqliteModule
-  return { db: new sqlite.DatabaseSync(dbPath), dbPath }
+  return { db: registerPlayerLookup(new sqlite.DatabaseSync(dbPath)), dbPath }
 }
 
 async function openWritableMarketDb(env: ServerEnv) {
@@ -463,7 +479,7 @@ async function openWritableMarketDb(env: ServerEnv) {
 
   const sqliteSpecifier = 'node:sqlite'
   const sqlite = (await import(sqliteSpecifier)) as unknown as SqliteModule
-  return { db: new sqlite.DatabaseSync(dbPath), dbPath }
+  return { db: registerPlayerLookup(new sqlite.DatabaseSync(dbPath)), dbPath }
 }
 
 async function openOptionalWritableMarketDb(env: ServerEnv) {
@@ -3485,7 +3501,7 @@ function localChecklistModelQuery(db: SqliteDatabase, releaseKey: string, source
       FROM players p
       JOIN canonical_cards cc
         ON cc.release_year = p.release_year
-       AND lower(cc.player_name) = lower(p.player_name)
+       AND normalize_player_lookup(cc.player_name) = normalize_player_lookup(p.player_name)
       JOIN canonical_comp_summary s
         ON s.canonical_card_key = cc.canonical_card_key
       WHERE cc.grade_bucket = 'Raw'
@@ -6684,7 +6700,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
     const params = new URL(request.url).searchParams
 
     if (route === 'coverage') {
-      const minYear = clampInt(params.get('minYear'), 2020, 1900, 9999)
+      const minYear = clampInt(params.get('minYear'), 2016, 1900, 9999)
       const staleDays = clampInt(params.has('staleDays') ? params.get('staleDays') : undefined, 60, 7, 730)
       const retryCooldownDays = clampInt(params.has('retryCooldownDays') ? params.get('retryCooldownDays') : undefined, 7, 0, 90)
       const requestedRelease = compactSqlText(String(params.get('release') ?? params.get('releaseKey') ?? ''))
@@ -6732,7 +6748,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
         base_candidates AS (
           SELECT
             cc.release_year,
-            lower(cc.player_name) AS player_lookup,
+            normalize_player_lookup(cc.player_name) AS player_lookup,
             cc.product_family,
             cc.variation_label,
             s.sale_count,
@@ -6741,7 +6757,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
             COALESCE(NULLIF(s.twma_30, 0), NULLIF(s.recent_5_avg, 0), NULLIF(s.twma_90, 0), NULLIF(s.median_price, 0), NULLIF(s.avg_price, 0), 0) AS base_price,
             s.latest_sold_at,
             ROW_NUMBER() OVER (
-              PARTITION BY cc.release_year, lower(cc.player_name)
+              PARTITION BY cc.release_year, normalize_player_lookup(cc.player_name)
               ORDER BY
                 CASE WHEN lower(cc.product_family) LIKE '%chrome%' THEN 0 ELSE 1 END,
                 s.sale_count DESC,
@@ -6776,7 +6792,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
         ? `
         LEFT JOIN base_candidates b
           ON b.release_year = cp.release_year
-         AND b.player_lookup = lower(cp.player_name)
+         AND b.player_lookup = normalize_player_lookup(cp.player_name)
          AND b.rn = 1`
         : ''
       const queueSelect = hasQueue
@@ -6878,7 +6894,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
         cadence: {
           hot: 'Hourly for players with fresh live-market hits and stale or missing price lanes.',
           priority: 'Nightly for ranked, team-page, and recently listed players.',
-          longTail: 'Weekly for the remaining 2020+ checklist backlog.',
+          longTail: 'Weekly for the remaining 2016+ checklist backlog.',
           retry: 'Timeout/error rows retry with smaller Card Hedge searches and alternate query wording.',
         },
         releases: [...releaseMap.values()].sort((left, right) => right.releaseYear - left.releaseYear || left.releaseName.localeCompare(right.releaseName)),
@@ -6905,7 +6921,7 @@ export async function handleChecklistRoute(route: string, request: Request, env:
           FROM checklist_cards c
           JOIN canonical_cards cc
             ON cc.release_year = c.release_year
-           AND lower(cc.player_name) = lower(c.player_name)
+           AND normalize_player_lookup(cc.player_name) = normalize_player_lookup(c.player_name)
           JOIN canonical_comp_summary s
             ON s.canonical_card_key = cc.canonical_card_key
           WHERE cc.grade_bucket = 'Raw'

--- a/src/lib/prospectPulse.ts
+++ b/src/lib/prospectPulse.ts
@@ -427,7 +427,10 @@ function mergeChecklistPlayers(primary: ChecklistPlayer[], localPlayers: Checkli
         ? localPlayer.baseSalesCount
         : existing.baseSalesCount,
       baseSales: localHasBase ? localPlayer.baseSales ?? existing.baseSales : existing.baseSales,
-      variations: existing.variations?.length ? existing.variations : localPlayer.variations,
+      variations:
+        (existing.variations?.length ?? 0) >= (localPlayer.variations?.length ?? 0)
+          ? existing.variations
+          : localPlayer.variations,
     })
   }
 
@@ -452,7 +455,10 @@ function mergeChecklistModels(remoteModel: ChecklistModel | null, localModel: Ch
       Math.max(remoteModel.activeChecklistPlayers ?? 0, localModel.activeChecklistPlayers ?? 0) ||
       remoteModel.activeChecklistPlayers ||
       localModel.activeChecklistPlayers,
-    multipliers: remoteModel.multipliers.length ? remoteModel.multipliers : localModel.multipliers,
+    multipliers:
+      remoteModel.multipliers.length >= localModel.multipliers.length
+        ? remoteModel.multipliers
+        : localModel.multipliers,
     players: mergeChecklistPlayers(remoteModel.players, localModel.players),
     fetchedAt: new Date().toISOString(),
     source: remoteModel.players.length ? remoteModel.source : localModel.source,
@@ -532,6 +538,17 @@ async function findStaticChecklistModel(options: {
     ...model,
     fetchedAt: STATIC_CHECKLIST_GENERATED_AT,
   }
+}
+
+export async function fetchStaticChecklistModels(options: {
+  minYear: number
+  categories: ChecklistModel['category'][]
+}) {
+  const { STATIC_CHECKLIST_MODELS } = await loadStaticChecklistSnapshot()
+  const categorySet = new Set(options.categories)
+  return STATIC_CHECKLIST_MODELS.filter(
+    (model) => model.releaseYear >= options.minYear && categorySet.has(model.category),
+  )
 }
 
 function binPriceBands(options: { minPrice?: number; maxPrice?: number | null; scanDepth?: FeedScanDepth }) {
@@ -881,13 +898,15 @@ export async function fetchChecklistModel(options: {
   const requestedRelease =
     options.release ??
     `${requestedReleaseYear}-${category === 'draft' ? 'Bowman-Draft' : category === 'chrome' ? 'Bowman-Chrome' : 'Bowman'}`
-  const localFirstModel = await fetchLocalChecklistModel(requestedRelease, options.signal).catch(() => null)
-  if (localFirstModel?.players?.length) return localFirstModel
   const staticFirstModel = await findStaticChecklistModel({
     category,
     year: requestedReleaseYear,
     release: requestedRelease,
   })
+  const localFirstModel = await fetchLocalChecklistModel(requestedRelease, options.signal).catch(() => null)
+  if (localFirstModel?.players?.length) {
+    return mergeChecklistModels(staticFirstModel, localFirstModel) ?? localFirstModel
+  }
 
   let remoteModel: ChecklistModel | null = null
   let remoteError: unknown = null
@@ -948,7 +967,8 @@ export async function fetchChecklistModel(options: {
       year: releaseYear,
       release: release || requestedRelease,
     }))
-  const merged = mergeChecklistModels(remoteModel, localModel ?? staticModel)
+  const baselineModel = mergeChecklistModels(staticModel, localModel)
+  const merged = mergeChecklistModels(remoteModel, baselineModel)
   if (merged) return merged
   if (remoteError) throw remoteError
   throw new Error('Checklist model load failed')


### PR DESCRIPTION
## Summary
- normalize player names across checklist and canonical comp joins, including accents and punctuation
- reject malformed release years from canonical market mappings
- prefer canonical base-auto summaries for historical projections
- merge static, hosted, and remote checklist coverage instead of dropping richer variation data
- improve private access form accessibility

The obsolete local UI experiment was archived separately and is not included.

## Verification
- npm run check
- 35 test files / 231 tests passed
- lint, typecheck, and production build passed